### PR TITLE
docs(tempo): add sample traces generator

### DIFF
--- a/katalog/tempo-distributed/MAINTENANCE.md
+++ b/katalog/tempo-distributed/MAINTENANCE.md
@@ -21,3 +21,14 @@ What was customized:
 
 - nginx-unprivileged image was bumped to the latest available version
 - PodDisruptionBudget apiVersion bumped to policy/v1
+
+
+## Testing the tracing stack
+
+You can use the manifest in `katalog/tests/sample-traces-cronjob.yaml` to create a cronjob that generates traces and sends them to Tempo.
+
+Once the crojob has run for some time, you can go to Grafana's Explore view, swith the datasource to Tempo, then select the "Search" query type.
+
+In the "Service Name" drop down you should be able to chose the value "telemetrygen", chose that and search for traces.
+
+The cronjob definition has been taken and adapted from: <https://grafana.com/docs/tempo/latest/setup/set-up-test-app/>

--- a/katalog/tests/sample-traces-cronjob.yaml
+++ b/katalog/tests/sample-traces-cronjob.yaml
@@ -1,0 +1,33 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sample-traces
+  namespace: tracing
+spec:
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 3600
+      template:
+        spec:
+          containers:
+            - name: traces
+              image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.96.0
+              args:
+                - traces
+                - --otlp-insecure
+                - --rate
+                - "20"
+                - --duration
+                - 5s
+                - --otlp-endpoint
+                - tempo-distributed-distributor.tracing.svc.cluster.local:4317
+          restartPolicy: Never


### PR DESCRIPTION
Add a cronjob that generates traces to the tests folder and instructions on how to use it to test that the tracing module is working properly.