### PR TITLE
Add 1.28 compatibility to v1.1.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -96,6 +96,86 @@ steps:
       - push
 
 ---
+name: e2e-kubernetes-1.28
+kind: pipeline
+type: docker
+
+depends_on:
+  - policeman
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: create Kind cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.29.1_3.10.0
+    pull: always
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_VERSION: v1.28.0
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      # /drone/src is the default workdir for the pipeline
+      # using this folder we don't need to mount another
+      # shared volume between the steps
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    commands:
+      # create a custom config to disable Kind's default CNI so
+      # we can test using KFD's networking module.
+      - |
+        cat <<EOF > kind-config.yaml
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        networking:
+          disableDefaultCNI: false
+        EOF
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: e2e
+    image: quay.io/sighup/e2e-testing:1.1.0_1.29.1_3.10.0_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+      FURYCTL_VERSION: v0.27.2
+    depends_on: [create Kind cluster]
+    commands:
+      - bats -t katalog/tests/tests.sh
+
+  - name: delete-kind-cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - e2e
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+---
 name: e2e-kubernetes-1.29
 kind: pipeline
 type: docker
@@ -341,6 +421,7 @@ kind: pipeline
 type: docker
 
 depends_on:
+  - e2e-kubernetes-1.28
   - e2e-kubernetes-1.29
   - e2e-kubernetes-1.30
   - e2e-kubernetes-1.31

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -5,8 +5,8 @@
 | v1.0.0                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
 | v1.0.1                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
 | v1.0.2                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
-| v1.0.3                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v1.1.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v1.0.3                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
+| v1.1.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -3,7 +3,7 @@
 Welcome to the latest release of the `tracing` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution)
 maintained by team SIGHUP.
 
-This patch release updates some components and adds support to Kubernetes 1.30 and 1.31
+This patch release updates some components and adds support to Kubernetes 1.30 and 1.31, while dropping support to Kubernetes <1.28.
 
 ## Changes
 


### PR DESCRIPTION
Successful CI at tag [v1.1.0-rc2](https://github.com/sighupio/fury-kubernetes-tracing/tree/v1.1.0-rc2)