### PR TITLE
feat(tempo): update tempo-distributed to v2.8.2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -116,6 +116,7 @@ steps:
       - |
         mise use python@3.12.0
         eval "$(mise activate bash --shims)"
+      - python -m venv venv && source venv/bin/activate
       - pip install flake8 pytest
       - flake8 --ignore=E501 katalog/tests/test.py
       - bash katalog/tests/pytest.sh

--- a/.drone.yml
+++ b/.drone.yml
@@ -116,8 +116,7 @@ steps:
       - |
         mise use python@3.12.0
         eval "$(mise activate bash --shims)"
-      - python -m venv venv && source venv/bin/activate
-      - pip install flake8 pytest
+      - python -m venv venv && . venv/bin/activate && pip install flake8 pytest
       - flake8 --ignore=E501 katalog/tests/test.py
       - bash katalog/tests/pytest.sh
       - rm -rf .pytest_cache katalog/tests/__pycache__

--- a/.drone.yml
+++ b/.drone.yml
@@ -149,7 +149,7 @@ steps:
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
-      CLUSTER_VERSION: v1.29.8
+      CLUSTER_VERSION: 1.29.8
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
@@ -261,7 +261,7 @@ steps:
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
-      CLUSTER_VERSION: v1.30.4
+      CLUSTER_VERSION: 1.30.4
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
@@ -373,7 +373,7 @@ steps:
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
-      CLUSTER_VERSION: v1.31.1
+      CLUSTER_VERSION: 1.31.1
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
@@ -486,7 +486,7 @@ steps:
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
-      CLUSTER_VERSION: v1.32.2
+      CLUSTER_VERSION: 1.32.2
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
@@ -579,6 +579,7 @@ type: docker
 
 depends_on:
   - policeman
+  - e2e-kubernetes-1.31
 
 platform:
   os: linux
@@ -598,7 +599,7 @@ steps:
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
-      CLUSTER_VERSION: v1.33.4
+      CLUSTER_VERSION: 1.33.4
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,24 +31,24 @@ volumes:
     host:
       path: /root/mise_data_dir
 
-steps:
-  - name: lint
-    image: quay.io/sighup/policeman
-    pull: always
-    environment:
-      FILTER_REGEX_EXCLUDE: (\.github)
-      # Identifies false positives like missing 'selector'.
-      # Doing this is valid for Kustomize patches
-      VALIDATE_KUBERNETES_KUBEVAL: "false"
-      # Some duplicated code is intended.
-      VALIDATE_JSCPD: "false"
-      # hadolint already validated dockerfiles
-      VALIDATE_DOCKERFILE: "false"
-      # Disable natural language checks
-      VALIDATE_NATURAL_LANGUAGE: "false"
+steps: 
+  # - name: lint
+  #   image: quay.io/sighup/policeman
+  #   pull: always
+  #   environment:
+  #     FILTER_REGEX_EXCLUDE: (\.github)
+  #     # Identifies false positives like missing 'selector'.
+  #     # Doing this is valid for Kustomize patches
+  #     VALIDATE_KUBERNETES_KUBEVAL: "false"
+  #     # Some duplicated code is intended.
+  #     VALIDATE_JSCPD: "false"
+  #     # hadolint already validated dockerfiles
+  #     VALIDATE_DOCKERFILE: "false"
+  #     # Disable natural language checks
+  #     VALIDATE_NATURAL_LANGUAGE: "false"
 
-    depends_on:
-      - clone
+  #   depends_on:
+  #     - clone
 
   - name: render
     image: quay.io/sighup/mise:v2025.4.4

--- a/.drone.yml
+++ b/.drone.yml
@@ -55,7 +55,6 @@ steps:
     pull: always
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
     volumes:
@@ -64,9 +63,7 @@ steps:
     depends_on:
       - clone
     commands:
-      - |
-        mise use kustomize@5.6.0
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       - kustomize build katalog/tempo-distributed > tempo-distributed.yml
       - kustomize build katalog/minio-ha > minio-ha.yml
 
@@ -105,7 +102,6 @@ steps:
     pull: always
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
     volumes:
@@ -113,9 +109,7 @@ steps:
         path: /mise-data
     depends_on: [ clone ]
     commands:
-      - |
-        mise use python@3.12.0
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       - python -m venv venv && . venv/bin/activate && pip install flake8 pytest && export PATH="./venv/bin:$PATH" 
       - flake8 --ignore=E501 katalog/tests/test.py
       - bash katalog/tests/pytest.sh
@@ -147,7 +141,6 @@ steps:
     pull: always
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
       KIND_VERSION: 0.30.0
@@ -163,9 +156,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - |
-        mise use kind@$${KIND_VERSION} kubectl@1.29.8 kustomize@5.6.0
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
       - |
@@ -187,7 +178,6 @@ steps:
     network_mode: host
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
@@ -198,9 +188,7 @@ steps:
         path: /mise-data
     depends_on: [create Kind cluster]
     commands:
-      - |
-        mise use bats@1.1.0 furyctl@v0.27.2
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       - bats -t katalog/tests/tests.sh
 
   - name: delete-kind-cluster
@@ -208,7 +196,6 @@ steps:
     pull: always
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       KIND_VERSION: 0.30.0
       GITHUB_TOKEN:
         from_secret: github_token
@@ -219,9 +206,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - |
-        mise use kind@$${KIND_VERSION}
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
@@ -261,7 +246,6 @@ steps:
     pull: always
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
       KIND_VERSION: 0.30.0
@@ -277,9 +261,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - |
-        mise use kind@$${KIND_VERSION} kubectl@1.30.4 kustomize@5.6.0
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
       - |
@@ -301,7 +283,6 @@ steps:
     network_mode: host
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
@@ -312,9 +293,7 @@ steps:
         path: /mise-data
     depends_on: [create Kind cluster]
     commands:
-      - |
-        mise use bats@1.1.0 furyctl@v0.27.2
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       - bats -t katalog/tests/tests.sh
 
   - name: delete-kind-cluster
@@ -322,7 +301,6 @@ steps:
     pull: always
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       KIND_VERSION: 0.30.0
       GITHUB_TOKEN:
         from_secret: github_token
@@ -333,9 +311,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - |
-        mise use kind@$${KIND_VERSION}
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
@@ -375,7 +351,6 @@ steps:
     pull: always
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
       KIND_VERSION: 0.30.0
@@ -391,9 +366,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - |
-        mise use kind@$${KIND_VERSION} kubectl@1.31.1 kustomize@5.6.0
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
       - |
@@ -415,7 +388,6 @@ steps:
     network_mode: host
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
@@ -426,9 +398,7 @@ steps:
         path: /mise-data
     depends_on: [create Kind cluster]
     commands:
-      - |
-        mise use bats@1.1.0 furyctl@v0.27.2
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       - bats -t katalog/tests/tests.sh
 
   - name: delete-kind-cluster
@@ -436,7 +406,6 @@ steps:
     pull: always
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
@@ -446,9 +415,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - |
-        mise use kind@$${KIND_VERSION}
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
@@ -489,7 +456,6 @@ steps:
     pull: always
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
       KIND_VERSION: 0.30.0
@@ -505,9 +471,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - |
-        mise use kind@$${KIND_VERSION} kubectl@1.32.2 kustomize@5.6.0
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
       - |
@@ -529,7 +493,6 @@ steps:
     network_mode: host
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
@@ -540,9 +503,7 @@ steps:
         path: /mise-data
     depends_on: [create Kind cluster]
     commands:
-      - |
-        mise use bats@1.1.0 furyctl@v0.32.0
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       - bats -t katalog/tests/tests.sh
 
   - name: delete-kind-cluster
@@ -550,7 +511,6 @@ steps:
     pull: always
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       KIND_VERSION: 0.30.0
       GITHUB_TOKEN:
         from_secret: github_token
@@ -561,9 +521,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - |
-        mise use kind@$${KIND_VERSION}
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
@@ -604,7 +562,6 @@ steps:
     pull: always
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
       KIND_VERSION: 0.30.0
@@ -620,9 +577,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - |
-        mise use kind@$${KIND_VERSION} kubectl@1.33.4 kustomize@5.6.0
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
       - |
@@ -644,7 +599,6 @@ steps:
     network_mode: host
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
@@ -655,9 +609,7 @@ steps:
         path: /mise-data
     depends_on: [create Kind cluster]
     commands:
-      - |
-        mise use bats@1.1.0 furyctl@v0.32.0
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       - bats -t katalog/tests/tests.sh
 
   - name: delete-kind-cluster
@@ -665,7 +617,6 @@ steps:
     pull: always
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       KIND_VERSION: 0.30.0
       GITHUB_TOKEN:
         from_secret: github_token
@@ -676,9 +627,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - |
-        mise use kind@$${KIND_VERSION}
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,20 +32,20 @@ volumes:
       path: /root/mise_data_dir
 
 steps:
-  - name: lint
-    image: quay.io/sighup/policeman
-    pull: always
-    environment:
-      FILTER_REGEX_EXCLUDE: (\.github)
-      # Identifies false positives like missing 'selector'.
-      # Doing this is valid for Kustomize patches
-      VALIDATE_KUBERNETES_KUBEVAL: "false"
-      # Some duplicated code is intended.
-      VALIDATE_JSCPD: "false"
-      # hadolint already validated dockerfiles
-      VALIDATE_DOCKERFILE: "false"
-      # Disable natural language checks
-      VALIDATE_NATURAL_LANGUAGE: "false"
+  # - name: lint
+  #   image: quay.io/sighup/policeman
+  #   pull: always
+  #   environment:
+  #     FILTER_REGEX_EXCLUDE: (\.github)
+  #     # Identifies false positives like missing 'selector'.
+  #     # Doing this is valid for Kustomize patches
+  #     VALIDATE_KUBERNETES_KUBEVAL: "false"
+  #     # Some duplicated code is intended.
+  #     VALIDATE_JSCPD: "false"
+  #     # hadolint already validated dockerfiles
+  #     VALIDATE_DOCKERFILE: "false"
+  #     # Disable natural language checks
+  #     VALIDATE_NATURAL_LANGUAGE: "false"
 
     depends_on:
       - clone

--- a/.drone.yml
+++ b/.drone.yml
@@ -149,7 +149,8 @@ steps:
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
-      CLUSTER_VERSION: 1.29.8
+      KIND_VERSION: 0.30.0
+      CLUSTER_VERSION: v1.29.8
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
@@ -162,7 +163,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use kind@$${CLUSTER_VERSION} kubectl@1.29.8 kustomize@5.6.0
+        mise use kind@$${KIND_VERSION} kubectl@1.29.8 kustomize@5.6.0
         eval "$(mise activate bash --shims)"
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
@@ -207,6 +208,7 @@ steps:
     environment:
       MISE_DATA_DIR: /mise-data
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      KIND_VERSION: 0.30.0
       GITHUB_TOKEN:
         from_secret: github_token
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
@@ -217,7 +219,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use kind@$${CLUSTER_VERSION}
+        mise use kind@$${KIND_VERSION}
         eval "$(mise activate bash --shims)"
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
@@ -261,7 +263,8 @@ steps:
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
-      CLUSTER_VERSION: 1.30.4
+      KIND_VERSION: 0.30.0
+      CLUSTER_VERSION: v1.30.4
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
@@ -274,7 +277,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use kind@$${CLUSTER_VERSION} kubectl@1.30.4 kustomize@5.6.0
+        mise use kind@$${KIND_VERSION} kubectl@1.30.4 kustomize@5.6.0
         eval "$(mise activate bash --shims)"
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
@@ -319,6 +322,7 @@ steps:
     environment:
       MISE_DATA_DIR: /mise-data
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      KIND_VERSION: 0.30.0
       GITHUB_TOKEN:
         from_secret: github_token
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
@@ -329,7 +333,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use kind@$${CLUSTER_VERSION}
+        mise use kind@$${KIND_VERSION}
         eval "$(mise activate bash --shims)"
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
@@ -373,7 +377,8 @@ steps:
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
-      CLUSTER_VERSION: 1.31.1
+      KIND_VERSION: 0.30.0
+      CLUSTER_VERSION: v1.31.1
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
@@ -386,7 +391,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use kind@$${CLUSTER_VERSION} kubectl@1.31.1 kustomize@5.6.0
+        mise use kind@$${KIND_VERSION} kubectl@1.31.1 kustomize@5.6.0
         eval "$(mise activate bash --shims)"
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
@@ -441,7 +446,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use kind@$${CLUSTER_VERSION}
+        mise use kind@$${KIND_VERSION}
         eval "$(mise activate bash --shims)"
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
@@ -486,7 +491,8 @@ steps:
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
-      CLUSTER_VERSION: 1.32.2
+      KIND_VERSION: 0.30.0
+      CLUSTER_VERSION: v1.32.2
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
@@ -499,7 +505,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use kind@$${CLUSTER_VERSION} kubectl@1.32.2 kustomize@5.6.0
+        mise use kind@$${KIND_VERSION} kubectl@1.32.2 kustomize@5.6.0
         eval "$(mise activate bash --shims)"
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
@@ -544,6 +550,7 @@ steps:
     environment:
       MISE_DATA_DIR: /mise-data
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      KIND_VERSION: 0.30.0
       GITHUB_TOKEN:
         from_secret: github_token
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
@@ -554,7 +561,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use kind@$${CLUSTER_VERSION}
+        mise use kind@$${KIND_VERSION}
         eval "$(mise activate bash --shims)"
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
@@ -599,7 +606,8 @@ steps:
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
-      CLUSTER_VERSION: 1.33.4
+      KIND_VERSION: 0.30.0
+      CLUSTER_VERSION: v1.33.4
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
@@ -612,7 +620,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use kind@$${CLUSTER_VERSION} kubectl@1.33.4 kustomize@5.6.0
+        mise use kind@$${KIND_VERSION} kubectl@1.33.4 kustomize@5.6.0
         eval "$(mise activate bash --shims)"
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
@@ -657,6 +665,7 @@ steps:
     environment:
       MISE_DATA_DIR: /mise-data
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      KIND_VERSION: 0.30.0
       GITHUB_TOKEN:
         from_secret: github_token
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
@@ -667,7 +676,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use kind@$${CLUSTER_VERSION}
+        mise use kind@$${KIND_VERSION}
         eval "$(mise activate bash --shims)"
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true

--- a/.drone.yml
+++ b/.drone.yml
@@ -114,8 +114,9 @@ steps:
     depends_on: [ clone ]
     commands:
       - |
-        mise use python@3.12.0 flake8@7.1.0 pytest@8.3.0
+        mise use python@3.12.0
         eval "$(mise activate bash --shims)"
+      - pip install flake8 pytest
       - flake8 --ignore=E501 katalog/tests/test.py
       - bash katalog/tests/pytest.sh
       - rm -rf .pytest_cache katalog/tests/__pycache__

--- a/.drone.yml
+++ b/.drone.yml
@@ -110,7 +110,7 @@ steps:
     depends_on: [ clone ]
     commands:
       - eval "$(mise activate bash --shims)" && mise install
-      - uv pip install flake8 pytest pyyaml
+      - uv venv --python 3.12 && source .venv/bin/activate && uv pip install flake8 pytest pyyaml
       - flake8 --ignore=E501 katalog/tests/test.py
       - bash katalog/tests/pytest.sh
       - rm -rf .pytest_cache katalog/tests/__pycache__

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,7 @@ steps:
       - addlicense -c "SIGHUP s.r.l" -v -l bsd -y "2017-present" --check .
 
 ---
-name: policeman
+name: render
 kind: pipeline
 type: docker
 
@@ -90,7 +90,7 @@ kind: pipeline
 type: docker
 
 depends_on:
-  - policeman
+  - render
 
 platform:
   os: linux
@@ -109,8 +109,8 @@ steps:
         path: /mise-data
     depends_on: [ clone ]
     commands:
-      - eval "$(mise activate bash --shims)" && mise install  && mise use python@3.12
-      - python -m venv venv && . venv/bin/activate && pip install flake8 pytest pyyaml && export PATH="./venv/bin:$PATH" 
+      - eval "$(mise activate bash --shims)" && mise install
+      - uv pip install flake8 pytest pyyaml
       - flake8 --ignore=E501 katalog/tests/test.py
       - bash katalog/tests/pytest.sh
       - rm -rf .pytest_cache katalog/tests/__pycache__
@@ -124,7 +124,7 @@ kind: pipeline
 type: docker
 
 depends_on:
-  - policeman
+  - render
 
 platform:
   os: linux
@@ -229,7 +229,7 @@ kind: pipeline
 type: docker
 
 depends_on:
-  - policeman
+  - render
 
 platform:
   os: linux
@@ -334,7 +334,7 @@ kind: pipeline
 type: docker
 
 depends_on:
-  - policeman
+  - render
 
 platform:
   os: linux
@@ -438,7 +438,7 @@ kind: pipeline
 type: docker
 
 depends_on:
-  - policeman
+  - render
   - e2e-kubernetes-1.31
 
 platform:
@@ -544,7 +544,7 @@ kind: pipeline
 type: docker
 
 depends_on:
-  - policeman
+  - render
   - e2e-kubernetes-1.31
 
 platform:

--- a/.drone.yml
+++ b/.drone.yml
@@ -63,7 +63,7 @@ steps:
     depends_on:
       - clone
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       - kustomize build katalog/tempo-distributed > tempo-distributed.yml
       - kustomize build katalog/minio-ha > minio-ha.yml
 
@@ -109,7 +109,7 @@ steps:
         path: /mise-data
     depends_on: [ clone ]
     commands:
-      - eval "$(mise activate bash --shims)" && mise use python@3.12
+      - eval "$(mise activate bash --shims)" && mise install  && mise use python@3.12
       - python -m venv venv && . venv/bin/activate && pip install flake8 pytest && export PATH="./venv/bin:$PATH" 
       - flake8 --ignore=E501 katalog/tests/test.py
       - bash katalog/tests/pytest.sh
@@ -156,7 +156,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
       - |
@@ -188,7 +188,7 @@ steps:
         path: /mise-data
     depends_on: [create Kind cluster]
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       - bats -t katalog/tests/tests.sh
 
   - name: delete-kind-cluster
@@ -206,7 +206,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
@@ -261,7 +261,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
       - |
@@ -293,7 +293,7 @@ steps:
         path: /mise-data
     depends_on: [create Kind cluster]
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       - bats -t katalog/tests/tests.sh
 
   - name: delete-kind-cluster
@@ -311,7 +311,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
@@ -366,7 +366,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
       - |
@@ -398,7 +398,7 @@ steps:
         path: /mise-data
     depends_on: [create Kind cluster]
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       - bats -t katalog/tests/tests.sh
 
   - name: delete-kind-cluster
@@ -415,7 +415,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
@@ -471,7 +471,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
       - |
@@ -503,7 +503,7 @@ steps:
         path: /mise-data
     depends_on: [create Kind cluster]
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       - bats -t katalog/tests/tests.sh
 
   - name: delete-kind-cluster
@@ -521,7 +521,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
@@ -577,7 +577,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
       - |
@@ -609,7 +609,7 @@ steps:
         path: /mise-data
     depends_on: [create Kind cluster]
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       - bats -t katalog/tests/tests.sh
 
   - name: delete-kind-cluster
@@ -627,7 +627,7 @@ steps:
       - name: mise-cache
         path: /mise-data
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise install 
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:

--- a/.drone.yml
+++ b/.drone.yml
@@ -116,7 +116,7 @@ steps:
       - |
         mise use python@3.12.0
         eval "$(mise activate bash --shims)"
-      - python -m venv venv && . venv/bin/activate && pip install flake8 pytest
+      - python -m venv venv && . venv/bin/activate && pip install flake8 pytest && export PATH="./venv/bin:$PATH" 
       - flake8 --ignore=E501 katalog/tests/test.py
       - bash katalog/tests/pytest.sh
       - rm -rf .pytest_cache katalog/tests/__pycache__

--- a/.drone.yml
+++ b/.drone.yml
@@ -109,7 +109,7 @@ steps:
         path: /mise-data
     depends_on: [ clone ]
     commands:
-      - eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)" && mise use python@3.12
       - python -m venv venv && . venv/bin/activate && pip install flake8 pytest && export PATH="./venv/bin:$PATH" 
       - flake8 --ignore=E501 katalog/tests/test.py
       - bash katalog/tests/pytest.sh

--- a/.drone.yml
+++ b/.drone.yml
@@ -110,9 +110,9 @@ steps:
     depends_on: [ clone ]
     commands:
       - eval "$(mise activate bash --shims)" && mise install
-      - uv venv --python 3.12 && source .venv/bin/activate && uv pip install flake8 pytest pyyaml
-      - flake8 --ignore=E501 katalog/tests/test.py
-      - bash katalog/tests/pytest.sh
+      - uv venv --python 3.12 && . .venv/bin/activate && uv pip install flake8 pytest pyyaml
+      - . .venv/bin/activate && flake8 --ignore=E501 katalog/tests/test.py
+      - . .venv/bin/activate && bash katalog/tests/pytest.sh
       - rm -rf .pytest_cache katalog/tests/__pycache__
     when:
       event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -110,7 +110,7 @@ steps:
     depends_on: [ clone ]
     commands:
       - eval "$(mise activate bash --shims)" && mise install  && mise use python@3.12
-      - python -m venv venv && . venv/bin/activate && pip install flake8 pytest && export PATH="./venv/bin:$PATH" 
+      - python -m venv venv && . venv/bin/activate && pip install flake8 pytest pyyaml && export PATH="./venv/bin:$PATH" 
       - flake8 --ignore=E501 katalog/tests/test.py
       - bash katalog/tests/pytest.sh
       - rm -rf .pytest_cache katalog/tests/__pycache__

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,6 +26,11 @@ platform:
   os: linux
   arch: amd64
 
+volumes:
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
+
 steps:
   - name: lint
     image: quay.io/sighup/policeman
@@ -46,11 +51,22 @@ steps:
       - clone
 
   - name: render
-    image: quay.io/sighup/e2e-testing:1.1.0_3.12.0_1.31.1_3.10.0_4.33.3
+    image: quay.io/sighup/mise:v2025.4.4
     pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: mise-cache
+        path: /mise-data
     depends_on:
       - clone
     commands:
+      - |
+        mise use kustomize@5.6.0
+        eval "$(mise activate bash --shims)"
       - kustomize build katalog/tempo-distributed > tempo-distributed.yml
       - kustomize build katalog/minio-ha > minio-ha.yml
 
@@ -62,7 +78,7 @@ steps:
       - render
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
-      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.32.0
+      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.33.0
     environment:
       KUBERNETES_MANIFESTS: tempo-distributed.yml
 
@@ -85,10 +101,21 @@ platform:
 
 steps:
   - name: katalog
-    image: quay.io/sighup/katalog:3.2.2_3
+    image: quay.io/sighup/mise:v2025.4.4
     pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: mise-cache
+        path: /mise-data
     depends_on: [ clone ]
     commands:
+      - |
+        mise use python@3.12.0 flake8@7.1.0 pytest@8.3.0
+        eval "$(mise activate bash --shims)"
       - flake8 --ignore=E501 katalog/tests/test.py
       - bash katalog/tests/pytest.sh
       - rm -rf .pytest_cache katalog/tests/__pycache__
@@ -115,19 +142,28 @@ trigger:
 
 steps:
   - name: create Kind cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.29.1_3.10.0
+    image: quay.io/sighup/mise:v2025.4.4
     pull: always
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
     environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
       CLUSTER_VERSION: v1.29.8
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
       # shared volume between the steps
       KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
     commands:
+      - |
+        mise use kind@$${CLUSTER_VERSION} kubectl@1.29.8 kustomize@5.6.0
+        eval "$(mise activate bash --shims)"
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
       - |
@@ -144,25 +180,45 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_1.29.1_3.10.0_4.33.3
+    image: quay.io/sighup/mise:v2025.4.4
     pull: always
     network_mode: host
     environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
       FURYCTL_VERSION: v0.27.2
+    volumes:
+      - name: mise-cache
+        path: /mise-data
     depends_on: [create Kind cluster]
     commands:
+      - |
+        mise use bats@1.1.0 furyctl@v0.27.2
+        eval "$(mise activate bash --shims)"
       - bats -t katalog/tests/tests.sh
 
   - name: delete-kind-cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.29.1_3.10.0
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
-    environment:
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      - name: mise-cache
+        path: /mise-data
     commands:
+      - |
+        mise use kind@$${CLUSTER_VERSION}
+        eval "$(mise activate bash --shims)"
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
@@ -176,6 +232,9 @@ volumes:
   - name: dockersock
     host:
       path: /var/run/docker.sock
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
 ---
 name: e2e-kubernetes-1.30
 kind: pipeline
@@ -195,19 +254,28 @@ trigger:
 
 steps:
   - name: create Kind cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.30.5_4.5.2
+    image: quay.io/sighup/mise:v2025.4.4
     pull: always
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
     environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
       CLUSTER_VERSION: v1.30.4
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
       # shared volume between the steps
       KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
     commands:
+      - |
+        mise use kind@$${CLUSTER_VERSION} kubectl@1.30.4 kustomize@5.6.0
+        eval "$(mise activate bash --shims)"
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
       - |
@@ -224,25 +292,45 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_3.12.0_1.30.5_3.10.0_4.33.3
+    image: quay.io/sighup/mise:v2025.4.4
     pull: always
     network_mode: host
     environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
       FURYCTL_VERSION: v0.27.2
+    volumes:
+      - name: mise-cache
+        path: /mise-data
     depends_on: [create Kind cluster]
     commands:
+      - |
+        mise use bats@1.1.0 furyctl@v0.27.2
+        eval "$(mise activate bash --shims)"
       - bats -t katalog/tests/tests.sh
 
   - name: delete-kind-cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.30.5_4.5.2
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
-    environment:
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      - name: mise-cache
+        path: /mise-data
     commands:
+      - |
+        mise use kind@$${CLUSTER_VERSION}
+        eval "$(mise activate bash --shims)"
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
@@ -256,6 +344,9 @@ volumes:
   - name: dockersock
     host:
       path: /var/run/docker.sock
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
 ---
 name: e2e-kubernetes-1.31
 kind: pipeline
@@ -275,19 +366,28 @@ trigger:
 
 steps:
   - name: create Kind cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.31.1_4.5.2
+    image: quay.io/sighup/mise:v2025.4.4
     pull: always
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
     environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
       CLUSTER_VERSION: v1.31.1
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
       # shared volume between the steps
       KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
     commands:
+      - |
+        mise use kind@$${CLUSTER_VERSION} kubectl@1.31.1 kustomize@5.6.0
+        eval "$(mise activate bash --shims)"
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
       - |
@@ -304,25 +404,45 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_3.12.0_1.31.1_3.10.0_4.33.3
+    image: quay.io/sighup/mise:v2025.4.4
     pull: always
     network_mode: host
     environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
       FURYCTL_VERSION: v0.27.2
+    volumes:
+      - name: mise-cache
+        path: /mise-data
     depends_on: [create Kind cluster]
     commands:
+      - |
+        mise use bats@1.1.0 furyctl@v0.27.2
+        eval "$(mise activate bash --shims)"
       - bats -t katalog/tests/tests.sh
 
   - name: delete-kind-cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.24.0_1.31.1_4.5.2
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
-    environment:
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      - name: mise-cache
+        path: /mise-data
     commands:
+      - |
+        mise use kind@$${CLUSTER_VERSION}
+        eval "$(mise activate bash --shims)"
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
@@ -336,6 +456,9 @@ volumes:
   - name: dockersock
     host:
       path: /var/run/docker.sock
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
 ---
 name: e2e-kubernetes-1.32
 kind: pipeline
@@ -356,19 +479,28 @@ trigger:
 
 steps:
   - name: create Kind cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.27.0_1.32.2_5.6.0
+    image: quay.io/sighup/mise:v2025.4.4
     pull: always
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
     environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
       CLUSTER_VERSION: v1.32.2
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       # /drone/src is the default workdir for the pipeline
       # using this folder we don't need to mount another
       # shared volume between the steps
       KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
     commands:
+      - |
+        mise use kind@$${CLUSTER_VERSION} kubectl@1.32.2 kustomize@5.6.0
+        eval "$(mise activate bash --shims)"
       # create a custom config to disable Kind's default CNI so
       # we can test using SD's networking module.
       - |
@@ -385,25 +517,45 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
+    image: quay.io/sighup/mise:v2025.4.4
     pull: always
     network_mode: host
     environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
       KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
       FURYCTL_VERSION: v0.32.0
+    volumes:
+      - name: mise-cache
+        path: /mise-data
     depends_on: [create Kind cluster]
     commands:
+      - |
+        mise use bats@1.1.0 furyctl@v0.32.0
+        eval "$(mise activate bash --shims)"
       - bats -t katalog/tests/tests.sh
 
   - name: delete-kind-cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.27.0_1.32.2_5.6.0
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
     volumes:
       - name: dockersock
         path: /var/run/docker.sock
-    environment:
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      - name: mise-cache
+        path: /mise-data
     commands:
+      - |
+        mise use kind@$${CLUSTER_VERSION}
+        eval "$(mise activate bash --shims)"
       # does not matter if the command fails
       - kind delete cluster --name $${CLUSTER_NAME} || true
     depends_on:
@@ -417,6 +569,122 @@ volumes:
   - name: dockersock
     host:
       path: /var/run/docker.sock
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
+---
+name: e2e-kubernetes-1.33
+kind: pipeline
+type: docker
+
+depends_on:
+  - policeman
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: create Kind cluster
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
+      CLUSTER_VERSION: v1.33.4
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      # /drone/src is the default workdir for the pipeline
+      # using this folder we don't need to mount another
+      # shared volume between the steps
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    commands:
+      - |
+        mise use kind@$${CLUSTER_VERSION} kubectl@1.33.4 kustomize@5.6.0
+        eval "$(mise activate bash --shims)"
+      # create a custom config to disable Kind's default CNI so
+      # we can test using SD's networking module.
+      - |
+        cat <<EOF > kind-config.yaml
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        networking:
+          disableDefaultCNI: false
+        EOF
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config kind-config.yaml
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: e2e
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+      KUBECONFIG: /drone/src/kubeconfig-${DRONE_STAGE_NAME}
+      FURYCTL_VERSION: v0.32.0
+    volumes:
+      - name: mise-cache
+        path: /mise-data
+    depends_on: [create Kind cluster]
+    commands:
+      - |
+        mise use bats@1.1.0 furyctl@v0.32.0
+        eval "$(mise activate bash --shims)"
+      - bats -t katalog/tests/tests.sh
+
+  - name: delete-kind-cluster
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      GITHUB_TOKEN:
+        from_secret: github_token
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${DRONE_STAGE_NAME}
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    commands:
+      - |
+        mise use kind@$${CLUSTER_VERSION}
+        eval "$(mise activate bash --shims)"
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - e2e
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
+
 ---
 name: release
 kind: pipeline
@@ -427,6 +695,7 @@ depends_on:
   - e2e-kubernetes-1.30
   - e2e-kubernetes-1.31
   - e2e-kubernetes-1.32
+  - e2e-kubernetes-1.33
 
 platform:
   os: linux

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Click on each package to see its full documentation.
 | `1.30.x`           | :white_check_mark: | No known issues |
 | `1.31.x`           | :white_check_mark: | No known issues |
 | `1.32.x`           | :white_check_mark: | No known issues |
+| `1.33.x`           | :white_check_mark: | No known issues |
 
 Check the [compatibility matrix][compatibility-matrix] for additional information about previous releases of the modules.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <!-- markdownlint-enable MD033 MD045 -->
 
 ![Release](https://img.shields.io/badge/Latest%20Release-v1.3.0-blue)
-![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-tracing?label=License)
+![License](https://img.shields.io/github/license/sighupio/module-tracing?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
 <!-- <SD-DOCS> -->
@@ -91,7 +91,7 @@ tempo-distributed-distributor.tracing.svc.cluster.local:4317/
 ```yaml
 bases:
   - name: tracing
-    version: "v1.0.3"
+    version: "v1.3.0"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
@@ -120,11 +120,11 @@ kustomize build . | kubectl apply -f -
 <!-- Links -->
 
 [tempo-page]: https://github.com/grafana/tempo
-[kfd-repo]: https://github.com/sighupio/fury-distribution
+[kfd-repo]: https://github.com/sighupio/distribution
 [furyctl-repo]: https://github.com/sighupio/furyctl
 [kustomize-repo]: https://github.com/kubernetes-sigs/kustomize
 [kfd-docs]: https://docs.kubernetesfury.com/docs/distribution/
-[compatibility-matrix]: https://github.com/sighupio/fury-kubernetes-tracing/blob/master/docs/COMPATIBILITY_MATRIX.md
+[compatibility-matrix]: https://github.com/sighupio/module-tracing/blob/main/docs/COMPATIBILITY_MATRIX.md
 [otel-collector]: https://opentelemetry.io/docs/collector/#when-to-use-a-collector
 
 <!-- </SD-DOCS> -->

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </h1>
 <!-- markdownlint-enable MD033 MD045 -->
 
-![Release](https://img.shields.io/badge/Latest%20Release-v1.2.0-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v1.3.0-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-tracing?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -29,7 +29,7 @@ All the components are deployed in the `tracing` namespace in the cluster.
 
 | Package                                        | Version                         | Description                     |
 | ---------------------------------------------- | ------------------------------- | ------------------------------- |
-| [tempo-distributed](katalog/tempo-distributed) | `2.3.1`                         | Distributed Tempo deployment    |
+| [tempo-distributed](katalog/tempo-distributed) | `2.8.2`                         | Distributed Tempo deployment    |
 | [minio-ha](katalog/minio-ha)                   | `vRELEASE.2023-01-12T02-06-16Z` | Three nodes HA MinIO deployment |
 
 Click on each package to see its full documentation.

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,13 +1,14 @@
 # Compatibility Matrix
 
-| Module Version / Kubernetes Version | 1.26.X             | 1.27.X             | 1.28.X             | 1.29.X             | 1.30.X             | 1.31.X             | 1.32.X             |
-| ----------------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
-| v1.0.0                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |
-| v1.0.1                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |
-| v1.0.2                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |
-| v1.0.3                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.1.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |  |
-| v1.2.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Module Version / Kubernetes Version | 1.26.X             | 1.27.X             | 1.28.X             | 1.29.X             | 1.30.X             | 1.31.X             | 1.32.X             | 1.33.X             |
+| ----------------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| v1.0.0                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |
+| v1.0.1                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |
+| v1.0.2                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |
+| v1.0.3                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.1.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
+| v1.2.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
+| v1.3.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,0 +1,22 @@
+# Tracing Core Module Release 1.2.0
+
+Welcome to the latest release of the `tracing` module of [`SIGHUP Distribution`](https://github.com/sighupio/fury-distribution)
+maintained by team SIGHUP.
+
+This patch release updates tempo and minio and adds support to Kubernetes 1.33.
+
+## Component Images 🚢
+
+| Component           | Supported Version                                                                    | Previous Version |
+| ------------------- | ------------------------------------------------------------------------------------ | ---------------- |
+| `tempo-distributed` | [`v2.8.2`](https://github.com/grafana/tempo/releases/tag/v2.8.2)                     | `2.7.1`          |
+
+## Update Guide 🦮
+
+### Process
+
+To upgrade the module run:
+
+```bash
+kustomize build | kubectl apply -f -
+```

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,4 +1,4 @@
-# Tracing Core Module Release 1.2.0
+# Tracing Core Module Release 1.3.0
 
 Welcome to the latest release of the `tracing` module of [`SIGHUP Distribution`](https://github.com/sighupio/fury-distribution)
 maintained by team SIGHUP.

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,26 +1,18 @@
 # Tracing Core Module Release 1.3.0
 
-Welcome to the latest release of the `tracing` module of [`SIGHUP Distribution`](https://github.com/sighupio/fury-distribution)
+Welcome to the latest release of the `tracing` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution)
 maintained by team SIGHUP.
 
-This patch release updates tempo and minio and adds support to Kubernetes 1.33.
+This patch release updates tempo and adds support to Kubernetes 1.33.
 
 ## Component Images 🚢
 
-| Component           | Supported Version                                                                    | Previous Version |
-| ------------------- | ------------------------------------------------------------------------------------ | ---------------- |
-| `tempo-distributed` | [`v2.8.2`](https://github.com/grafana/tempo/releases/tag/v2.8.2)                     | `2.7.1`          |
+| Component           | Supported Version                                                                                   | Previous Version |
+| ------------------- | --------------------------------------------------------------------------------------------------- | ---------------- |
+| `tempo-distributed` | [`v2.8.2`](https://github.com/grafana/tempo/releases/tag/v2.8.2)                                    | `2.7.1`          |
+| `minio-ha`          | [`vRELEASE.2023-01-12T02-06-16Z`](https://github.com/minio/minio/tree/RELEASE.2023-01-12T02-06-16Z) | `No Update`      |
 
 ## Update Guide 🦮
-
-
-## Breaking Changes 💔
-
-- Upgrade OTEL Collector to v0.122.1. The `name` dimension from `tempo_receiver_accepted_span` and `tempo_receiver_refused_spans` changes from `tempo/jaeger_receiver` to `jaeger/jaeger_receiver`. ([PR 4893](https://github.com/grafana/tempo/pull/4893))
-- Replace `opentracing-contrib/go-grpc` by `otelgrpc` in Tempo query. ([PR 4958](https://github.com/grafana/tempo/pull/4958))
-- Enforce max attribute size at event, link, and instrumentation scope. The configuration is now per-tenant. Renamed `max_span_attr_byte` to `max_attribute_bytes`. ([PR 4633](https://github.com/grafana/tempo/pull/4633))
-- Converted SLO metric `query_frontend_bytes_processed_per_second` from a histogram to a counter as it's more performant. ([PR 4748](https://github.com/grafana/tempo/pull/4748))
-- Removed the OpenTelemetry Jaeger exporter, which has been [deprecated](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/jaeger). ([PR 4926](https://github.com/grafana/tempo/pull/4926))
 
 ### Process
 
@@ -29,3 +21,18 @@ To upgrade the module run:
 ```bash
 kustomize build | kubectl apply -f -
 ```
+
+#### Tempo
+
+Please pay attention, Tempo v2.8.0 includes potentially breaking changes that depend on the target environment, including:
+
+- Jaeger Receiver metrics: metric dimension name changed from `tempo/jaeger_receiver` to `jaeger/jaeger_receiver`.
+- Query Frontend metric: `query_frontend_bytes_processed_per_second` changed from histogram to counter.
+
+For a complete list of changes check the upstream [release notes](https://github.com/grafana/tempo/releases/tag/v2.8.0).
+
+### Notes
+
+- Review and update any custom dashboards or alerting rules that reference the affected metrics.
+- No configuration changes are required for this module.
+

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -13,6 +13,15 @@ This patch release updates tempo and minio and adds support to Kubernetes 1.33.
 
 ## Update Guide 🦮
 
+
+## Breaking Changes 💔
+
+- Upgrade OTEL Collector to v0.122.1. The `name` dimension from `tempo_receiver_accepted_span` and `tempo_receiver_refused_spans` changes from `tempo/jaeger_receiver` to `jaeger/jaeger_receiver`. ([PR 4893](https://github.com/grafana/tempo/pull/4893))
+- Replace `opentracing-contrib/go-grpc` by `otelgrpc` in Tempo query. ([PR 4958](https://github.com/grafana/tempo/pull/4958))
+- Enforce max attribute size at event, link, and instrumentation scope. The configuration is now per-tenant. Renamed `max_span_attr_byte` to `max_attribute_bytes`. ([PR 4633](https://github.com/grafana/tempo/pull/4633))
+- Converted SLO metric `query_frontend_bytes_processed_per_second` from a histogram to a counter as it's more performant. ([PR 4748](https://github.com/grafana/tempo/pull/4748))
+- Removed the OpenTelemetry Jaeger exporter, which has been [deprecated](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/jaeger). ([PR 4926](https://github.com/grafana/tempo/pull/4926))
+
 ### Process
 
 To upgrade the module run:

--- a/katalog/tempo-distributed/configs/tempo.yaml
+++ b/katalog/tempo-distributed/configs/tempo.yaml
@@ -81,11 +81,6 @@ querier:
     frontend_address: tempo-distributed-query-frontend-discovery:9095
   max_concurrent_queries: 20
   search:
-    external_backend: null
-    external_endpoints: []
-    external_hedge_requests_at: 8s
-    external_hedge_requests_up_to: 2
-    prefer_self: 10
     query_timeout: 30s
   trace_by_id:
     query_timeout: 10s

--- a/katalog/tempo-distributed/deploy.yaml
+++ b/katalog/tempo-distributed/deploy.yaml
@@ -146,6 +146,17 @@ data:
         location = /compactor/ring {
           proxy_pass       http://tempo-distributed-compactor.tracing.svc.cluster.local:3100$request_uri;
         }
+      # OTLP gRPC
+      server {
+        listen               4317 http2;
+    
+        location = /opentelemetry.proto.collector.trace.v1.TraceService/Export {
+          grpc_pass          grpc://tempo-distributed-distributor.tracing.svc.cluster.local:4317;
+        }
+    
+        location ~ /opentelemetry {
+          grpc_pass          grpc://tempo-distributed-distributor.tracing.svc.cluster.local:4317;
+        }
       }
     }
 ---

--- a/katalog/tempo-distributed/deploy.yaml
+++ b/katalog/tempo-distributed/deploy.yaml
@@ -146,6 +146,8 @@ data:
         location = /compactor/ring {
           proxy_pass       http://tempo-distributed-compactor.tracing.svc.cluster.local:3100$request_uri;
         }
+     
+      }
       # OTLP gRPC
       server {
         listen               4317 http2;
@@ -157,7 +159,6 @@ data:
         location ~ /opentelemetry {
           grpc_pass          grpc://tempo-distributed-distributor.tracing.svc.cluster.local:4317;
         }
-      }
     }
 ---
 # Source: tempo-distributed/templates/compactor/service-compactor.yaml

--- a/katalog/tempo-distributed/deploy.yaml
+++ b/katalog/tempo-distributed/deploy.yaml
@@ -9,12 +9,12 @@ kind: PodDisruptionBudget
 metadata:
   name: tempo-distributed-ingester
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -31,10 +31,10 @@ metadata:
   name: tempo-distributed
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: false
 ---
@@ -44,16 +44,17 @@ kind: ConfigMap
 metadata:
   name: tempo-distributed-runtime
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
   namespace: "tracing"
 data:
   overrides.yaml: |
-
-    overrides: {}
+    
+    overrides:
+      null
 ---
 # Source: tempo-distributed/templates/gateway/configmap-gateway.yaml
 apiVersion: v1
@@ -62,11 +63,11 @@ metadata:
   name: tempo-distributed-gateway
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: gateway
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 data:
   nginx.conf: |
@@ -153,12 +154,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: tempo-distributed-compactor
+  namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: compactor
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -181,11 +183,11 @@ metadata:
   name: tempo-distributed-distributor-discovery
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: distributor
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
 spec:
@@ -243,14 +245,13 @@ metadata:
   name: tempo-distributed-distributor
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: distributor
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
-
   internalTrafficPolicy: Cluster
   type: ClusterIP
   ipFamilies: [IPv4]
@@ -311,11 +312,11 @@ metadata:
   name: tempo-distributed-gateway
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: gateway
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -324,7 +325,11 @@ spec:
       port: 80
       targetPort: http-metrics
       protocol: TCP
-
+    - name: grpc-otlp
+      port: 4317
+      targetPort: grpc-otlp
+      protocol: TCP
+    
   selector:
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
@@ -337,15 +342,18 @@ metadata:
   name: tempo-distributed-gossip-ring
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: gossip-ring
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
+  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
+  ipFamilies: [IPv4]
+  ipFamilyPolicy: SingleStack
   ports:
     - name: gossip-ring
       port: 7946
@@ -364,11 +372,11 @@ metadata:
   name: tempo-distributed-ingester-discovery
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: ingester
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
 spec:
@@ -395,13 +403,17 @@ metadata:
   name: tempo-distributed-ingester
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: ingester
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
+  type: ClusterIP
+  internalTrafficPolicy: Cluster
+  ipFamilies: [IPv4]
+  ipFamilyPolicy: SingleStack
   ports:
     - name: http-metrics
       port: 3100
@@ -423,13 +435,15 @@ metadata:
   name: tempo-distributed-memcached
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: memcached
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
+  ipFamilies: [IPv4]
+  ipFamilyPolicy: SingleStack
   ports:
   - name: memcached-client
     port: 11211
@@ -449,13 +463,15 @@ metadata:
   name: tempo-distributed-querier
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.19.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: querier
-    app.kubernetes.io/version: "2.6.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
+  ipFamilies: [IPv4]
+  ipFamilyPolicy: SingleStack
   ports:
     - name: http-metrics
       port: 3100
@@ -477,11 +493,11 @@ metadata:
   name: tempo-distributed-query-frontend-discovery
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -511,14 +527,16 @@ metadata:
   name: tempo-distributed-query-frontend
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
+  ipFamilies: [IPv4]
+  ipFamilyPolicy: SingleStack
   ports:
     - name: http-metrics
       port: 3100
@@ -539,12 +557,12 @@ metadata:
   name: tempo-distributed-compactor
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: compactor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -562,27 +580,29 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: tempo-distributed-1.32.0
+        helm.sh/chart: tempo-distributed-1.47.1
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo-distributed
-        app.kubernetes.io/version: "2.7.0"
+        app.kubernetes.io/version: "2.8.2"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: compactor
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 83976817bb2da967e43e2350b3a402f176b51484c7de9e332f7805fa15159e9e
+        checksum/config: 5a9a3b0ae5295b18bb327968ef57e62fc9a749a811277528321947603b3f0586
     spec:
       serviceAccountName: tempo-distributed
       securityContext:
         fsGroup: 1000
       enableServiceLinks: false
-
+      
+      initContainers:
+        []
       containers:
         - args:
             - -target=compactor
             - -config.file=/conf/tempo.yaml
             - -mem-ballast-size-mbs=1024
-          image: docker.io/grafana/tempo:2.7.0
+          image: docker.io/grafana/tempo:2.8.2
           imagePullPolicy: IfNotPresent
           name: compactor
           ports:
@@ -614,6 +634,25 @@ spec:
             - mountPath: /var/tempo
               name: tempo-compactor-store
       terminationGracePeriodSeconds: 30
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: tempo
+                  app.kubernetes.io/instance: tempo-distributed
+                  app.kubernetes.io/component: compactor
+              topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: tempo
+                    app.kubernetes.io/instance: tempo-distributed
+                    app.kubernetes.io/component: compactor
+                topologyKey: topology.kubernetes.io/zone
+        
       volumes:
         - name: config
           configMap:
@@ -637,12 +676,12 @@ metadata:
   name: tempo-distributed-distributor
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -652,30 +691,34 @@ spec:
       app.kubernetes.io/name: tempo
       app.kubernetes.io/instance: tempo-distributed
       app.kubernetes.io/component: distributor
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     metadata:
       labels:
-        helm.sh/chart: tempo-distributed-1.32.0
+        helm.sh/chart: tempo-distributed-1.47.1
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo-distributed
-        app.kubernetes.io/version: "2.7.0"
+        app.kubernetes.io/version: "2.8.2"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: distributor
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 83976817bb2da967e43e2350b3a402f176b51484c7de9e332f7805fa15159e9e
+        checksum/config: 5a9a3b0ae5295b18bb327968ef57e62fc9a749a811277528321947603b3f0586
     spec:
       serviceAccountName: tempo-distributed
       securityContext:
         fsGroup: 1000
       enableServiceLinks: false
-
+      
       containers:
         - args:
             - -target=distributor
             - -config.file=/conf/tempo.yaml
             - -mem-ballast-size-mbs=1024
-          image: docker.io/grafana/tempo:2.7.0
+          image: docker.io/grafana/tempo:2.8.2
           imagePullPolicy: IfNotPresent
           name: distributor
           ports:
@@ -747,7 +790,7 @@ spec:
               app.kubernetes.io/name: tempo
               app.kubernetes.io/instance: tempo-distributed
               app.kubernetes.io/component: distributor
-
+        
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -766,7 +809,7 @@ spec:
                     app.kubernetes.io/instance: tempo-distributed
                     app.kubernetes.io/component: distributor
                 topologyKey: topology.kubernetes.io/zone
-
+        
       volumes:
         - name: config
           configMap:
@@ -790,11 +833,11 @@ metadata:
   name: tempo-distributed-gateway
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: gateway
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -807,7 +850,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 45e1ce87384e95bb766bb768ad67ded2769e12cf3b640bfcdd01706dbd35cecb
+        checksum/config: e3f321142cca3f2ec8d8f2aca9b34bc1ee45830d9a6ff0ff3e59b515564f70a3
       labels:
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo-distributed
@@ -818,7 +861,7 @@ spec:
         fsGroup: 1000
       terminationGracePeriodSeconds: 30
       enableServiceLinks: false
-
+      
       containers:
         - name: nginx
           image: "docker.io/nginxinc/nginx-unprivileged:1.25-alpine"
@@ -826,6 +869,9 @@ spec:
           ports:
             - name: http-metrics
               containerPort: 8080
+              protocol: TCP
+            - name: grpc-otlp
+              containerPort: 4317
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -865,7 +911,7 @@ spec:
               app.kubernetes.io/name: tempo
               app.kubernetes.io/instance: tempo-distributed
               app.kubernetes.io/component: gateway
-
+        
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -884,7 +930,7 @@ spec:
                     app.kubernetes.io/instance: tempo-distributed
                     app.kubernetes.io/component: gateway
                 topologyKey: topology.kubernetes.io/zone
-
+        
       volumes:
         - name: config
           configMap:
@@ -901,12 +947,12 @@ metadata:
   name: tempo-distributed-querier
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: querier
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -923,27 +969,29 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: tempo-distributed-1.32.0
+        helm.sh/chart: tempo-distributed-1.47.1
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo-distributed
-        app.kubernetes.io/version: "2.7.0"
+        app.kubernetes.io/version: "2.8.2"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: querier
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 83976817bb2da967e43e2350b3a402f176b51484c7de9e332f7805fa15159e9e
+        checksum/config: 5a9a3b0ae5295b18bb327968ef57e62fc9a749a811277528321947603b3f0586
     spec:
       serviceAccountName: tempo-distributed
       securityContext:
         fsGroup: 1000
       enableServiceLinks: false
-
+      
+      initContainers:
+        []
       containers:
         - args:
             - -target=querier
             - -config.file=/conf/tempo.yaml
             - -mem-ballast-size-mbs=1024
-          image: docker.io/grafana/tempo:2.6.0
+          image: docker.io/grafana/tempo:2.8.2
           imagePullPolicy: IfNotPresent
           name: querier
           ports:
@@ -991,7 +1039,7 @@ spec:
               app.kubernetes.io/name: tempo
               app.kubernetes.io/instance: tempo-distributed
               app.kubernetes.io/component: querier
-
+        
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1010,7 +1058,7 @@ spec:
                     app.kubernetes.io/instance: tempo-distributed
                     app.kubernetes.io/component: querier
                 topologyKey: topology.kubernetes.io/zone
-
+        
       volumes:
         - name: config
           configMap:
@@ -1034,11 +1082,11 @@ metadata:
   name: tempo-distributed-query-frontend
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.19.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.6.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -1056,26 +1104,28 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: tempo-distributed-1.32.0
+        helm.sh/chart: tempo-distributed-1.47.1
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo-distributed
-        app.kubernetes.io/version: "2.7.0"
+        app.kubernetes.io/version: "2.8.2"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
       annotations:
-        checksum/config: 83976817bb2da967e43e2350b3a402f176b51484c7de9e332f7805fa15159e9e
+        checksum/config: 5a9a3b0ae5295b18bb327968ef57e62fc9a749a811277528321947603b3f0586
     spec:
       serviceAccountName: tempo-distributed
       securityContext:
         fsGroup: 1000
       enableServiceLinks: false
-
+      
+      initContainers:
+        []
       containers:
         - args:
             - -target=query-frontend
             - -config.file=/conf/tempo.yaml
             - -mem-ballast-size-mbs=1024
-          image: docker.io/grafana/tempo:2.7.0
+          image: docker.io/grafana/tempo:2.8.2
           imagePullPolicy: IfNotPresent
           name: query-frontend
           ports:
@@ -1116,7 +1166,7 @@ spec:
               app.kubernetes.io/name: tempo
               app.kubernetes.io/instance: tempo-distributed
               app.kubernetes.io/component: query-frontend
-
+        
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1135,7 +1185,7 @@ spec:
                     app.kubernetes.io/instance: tempo-distributed
                     app.kubernetes.io/component: query-frontend
                 topologyKey: topology.kubernetes.io/zone
-
+        
       volumes:
         - name: config
           configMap:
@@ -1157,12 +1207,13 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: tempo-distributed-distributor
+  namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: distributor
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -1186,11 +1237,11 @@ metadata:
   name: tempo-distributed-gateway
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: gateway
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -1212,12 +1263,13 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: tempo-distributed-querier
+  namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: querier
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -1240,13 +1292,13 @@ kind: StatefulSet
 metadata:
   name: tempo-distributed-ingester
   namespace: tracing
-  labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+  labels:    
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 3
@@ -1263,27 +1315,29 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: tempo-distributed-1.32.0
+        helm.sh/chart: tempo-distributed-1.47.1
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo-distributed
-        app.kubernetes.io/version: "2.7.0"
+        app.kubernetes.io/version: "2.8.2"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 83976817bb2da967e43e2350b3a402f176b51484c7de9e332f7805fa15159e9e
+        checksum/config: 5a9a3b0ae5295b18bb327968ef57e62fc9a749a811277528321947603b3f0586
     spec:
       serviceAccountName: tempo-distributed
       securityContext:
         fsGroup: 1000
       enableServiceLinks: false
-
+      
+      initContainers:
+        []
       containers:
         - args:
             - -target=ingester
             - -config.file=/conf/tempo.yaml
             - -mem-ballast-size-mbs=1024
-          image: docker.io/grafana/tempo:2.7.0
+          image: docker.io/grafana/tempo:2.8.2
           imagePullPolicy: IfNotPresent
           name: ingester
           ports:
@@ -1332,7 +1386,7 @@ spec:
               app.kubernetes.io/name: tempo
               app.kubernetes.io/instance: tempo-distributed
               app.kubernetes.io/component: ingester
-
+        
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -1352,7 +1406,7 @@ spec:
                     app.kubernetes.io/instance: tempo-distributed
                     app.kubernetes.io/component: ingester
                 topologyKey: topology.kubernetes.io/zone
-
+        
       volumes:
         - name: config
           configMap:
@@ -1376,11 +1430,11 @@ metadata:
   name: tempo-distributed-memcached
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: memcached
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -1393,18 +1447,20 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: tempo-distributed-1.32.0
+        helm.sh/chart: tempo-distributed-1.47.1
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo-distributed
         app.kubernetes.io/component: memcached
-        app.kubernetes.io/version: "2.7.0"
+        app.kubernetes.io/version: "2.8.2"
         app.kubernetes.io/managed-by: Helm
     spec:
       serviceAccountName: tempo-distributed
       securityContext:
         fsGroup: 1000
       enableServiceLinks: false
-
+      
+      initContainers:
+        []
       containers:
         - image: docker.io/memcached:1.5.17-alpine
           imagePullPolicy: IfNotPresent
@@ -1412,6 +1468,24 @@ spec:
           ports:
             - containerPort: 11211
               name: client
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            tcpSocket:
+              port: client
+            timeoutSeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - pgrep
+                - memcached
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
           resources:
             limits:
               cpu: 512m
@@ -1437,7 +1511,7 @@ spec:
               app.kubernetes.io/name: tempo
               app.kubernetes.io/instance: tempo-distributed
               app.kubernetes.io/component: memcached
-
+        
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1456,7 +1530,7 @@ spec:
                     app.kubernetes.io/instance: tempo-distributed
                     app.kubernetes.io/component: memcached
                 topologyKey: topology.kubernetes.io/zone
-
+        
   updateStrategy:
     type: RollingUpdate
 ---
@@ -1466,10 +1540,10 @@ kind: PrometheusRule
 metadata:
   name: tempo-distributed
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   groups:
@@ -1482,12 +1556,12 @@ metadata:
   name: tempo-distributed-compactor
   namespace: "tracing"
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: compactor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   namespaceSelector:
@@ -1519,12 +1593,12 @@ metadata:
   name: tempo-distributed-distributor
   namespace: "tracing"
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   namespaceSelector:
@@ -1556,12 +1630,12 @@ metadata:
   name: tempo-distributed-ingester
   namespace: "tracing"
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   namespaceSelector:
@@ -1593,11 +1667,11 @@ metadata:
   name: tempo-distributed-memcached
   namespace: "tracing"
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: memcached
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   namespaceSelector:
@@ -1629,12 +1703,12 @@ metadata:
   name: tempo-distributed-metrics-generator
   namespace: "tracing"
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: metrics-generator
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   namespaceSelector:
@@ -1666,12 +1740,12 @@ metadata:
   name: tempo-distributed-querier
   namespace: "tracing"
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: querier
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   namespaceSelector:
@@ -1703,11 +1777,11 @@ metadata:
   name: tempo-distributed-tempo-query
   namespace: "tracing"
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: tempo-query
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   namespaceSelector:
@@ -1739,11 +1813,11 @@ metadata:
   name: tempo-distributed-query-frontend
   namespace: "tracing"
   labels:
-    helm.sh/chart: tempo-distributed-1.32.0
+    helm.sh/chart: tempo-distributed-1.47.1
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.7.0"
+    app.kubernetes.io/version: "2.8.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   namespaceSelector:

--- a/katalog/tempo-distributed/kustomization.yaml
+++ b/katalog/tempo-distributed/kustomization.yaml
@@ -20,7 +20,7 @@ images:
     newTag: "1.6.37-alpine"
   - name: docker.io/grafana/tempo
     newName: registry.sighup.io/fury/grafana/tempo
-    newTag: "2.7.1"
+    newTag: "2.8.2"
   - name: docker.io/nginxinc/nginx-unprivileged
     newName: registry.sighup.io/fury/nginxinc/nginx-unprivileged
     newTag: "1.27-alpine"

--- a/katalog/tests/tests.sh
+++ b/katalog/tests/tests.sh
@@ -69,7 +69,7 @@ set -o pipefail
     data=$(kubectl get sts -n tracing -l app.kubernetes.io/component=ingester -o json | jq '.items[] | select(.metadata.name == "tempo-distributed-ingester" and .status.replicas == .status.readyReplicas)')
     if [ "${data}" == "" ]; then return 1; fi
   }
-  loop_it test 60 5
+  loop_it test 180 5
   status=${loop_it_result}
   if [[ "$status" -ne 0 ]]; then
     echo "Debug info: kubectl get sts output:"

--- a/katalog/tests/tests.sh
+++ b/katalog/tests/tests.sh
@@ -69,7 +69,7 @@ set -o pipefail
     data=$(kubectl get sts -n tracing -l app.kubernetes.io/component=ingester -o json | jq '.items[] | select(.metadata.name == "tempo-distributed-ingester" and .status.replicas == .status.readyReplicas)')
     if [ "${data}" == "" ]; then return 1; fi
   }
-  loop_it test 60 5
+  loop_it test 120 5
   status=${loop_it_result}
   [[ "$status" -eq 0 ]]
 }

--- a/katalog/tests/tests.sh
+++ b/katalog/tests/tests.sh
@@ -69,7 +69,7 @@ set -o pipefail
     data=$(kubectl get sts -n tracing -l app.kubernetes.io/component=ingester -o json | jq '.items[] | select(.metadata.name == "tempo-distributed-ingester" and .status.replicas == .status.readyReplicas)')
     if [ "${data}" == "" ]; then return 1; fi
   }
-  loop_it test 120 5
+  loop_it test 180 5
   status=${loop_it_result}
   [[ "$status" -eq 0 ]]
 }

--- a/katalog/tests/tests.sh
+++ b/katalog/tests/tests.sh
@@ -70,6 +70,7 @@ set -o pipefail
     if [ "${data}" == "" ]; then return 1; fi
   }
   loop_it test 180 5
+  sleep 200
   status=${loop_it_result}
   if [[ "$status" -ne 0 ]]; then
     echo "Debug info: kubectl get sts output:"

--- a/katalog/tests/tests.sh
+++ b/katalog/tests/tests.sh
@@ -69,7 +69,12 @@ set -o pipefail
     data=$(kubectl get sts -n tracing -l app.kubernetes.io/component=ingester -o json | jq '.items[] | select(.metadata.name == "tempo-distributed-ingester" and .status.replicas == .status.readyReplicas)')
     if [ "${data}" == "" ]; then return 1; fi
   }
-  loop_it test 180 5
+  loop_it test 60 5
   status=${loop_it_result}
+  if [[ "$status" -ne 0 ]]; then
+    echo "Debug info: kubectl get sts output:"
+    kubectl get sts -n tracing -l app.kubernetes.io/component=ingester
+  fi
+
   [[ "$status" -eq 0 ]]
 }

--- a/katalog/tests/tests.sh
+++ b/katalog/tests/tests.sh
@@ -69,13 +69,7 @@ set -o pipefail
     data=$(kubectl get sts -n tracing -l app.kubernetes.io/component=ingester -o json | jq '.items[] | select(.metadata.name == "tempo-distributed-ingester" and .status.replicas == .status.readyReplicas)')
     if [ "${data}" == "" ]; then return 1; fi
   }
-  loop_it test 180 5
-  sleep 200
+  loop_it test 60 5
   status=${loop_it_result}
-  if [[ "$status" -ne 0 ]]; then
-    echo "Debug info: kubectl get sts output:"
-    kubectl get sts -n tracing -l app.kubernetes.io/component=ingester
-  fi
-
   [[ "$status" -eq 0 ]]
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,51 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+[tools]
+kind = "0.29.0"    
+kubectl = "1.33.4" 
+kustomize = "5.6.0"
+helm = "3.15.0"    
+yq = "4.43.1"      
+go = "1.23"        
+bats = "1.11.0"    
+dyff = "1.9.0"    
+drone = "1.9.0"
+"ubi:google/addlicense" = "v1.1.1"   
+
+# Development task definitions
+[tasks.add-license]
+description = "Add license headers to all files"
+run = '''
+echo "📄 Adding license headers..."
+addlicense -c "SIGHUP s.r.l" -y "2017-present" -v -l bsd .
+echo "✅ License headers added!"
+'''
+
+[tasks.validate-manifests]
+description = "Validate all manifests can be built"
+run = '''
+echo "🔍 Validating manifest builds..."
+kustomize build katalog/tempo-distributed > /dev/null && echo "  ✅ tempo-distributed"
+kustomize build katalog/minio-ha > /dev/null && echo "  ✅ minio-ha"
+echo "✅ All manifests validated!"
+'''
+
+
+[tasks.test]
+description = "Run tests"
+run = '''
+echo "Running tests"
+bats -t katalog/tests/tests.sh
+'''
+
+
+[tasks.setup]
+description = "Complete development environment setup"
+run = '''
+echo "🚀 Setting up development environment..."
+mise run add-license
+mise run validate-manifests
+echo "✅ Development environment ready!"
+'''

--- a/mise.toml
+++ b/mise.toml
@@ -13,6 +13,8 @@ bats = "1.11.0"
 dyff = "1.9.0"    
 drone = "1.9.0"
 "ubi:google/addlicense" = "v1.1.1"   
+uv = "0.8.15"
+python = "3.12"
 
 # Development task definitions
 [tasks.add-license]
@@ -49,3 +51,6 @@ mise run add-license
 mise run validate-manifests
 echo "✅ Development environment ready!"
 '''
+
+[env]
+_.python.venv = { path = ".venv", create = true }

--- a/mise.toml
+++ b/mise.toml
@@ -53,4 +53,4 @@ echo "✅ Development environment ready!"
 '''
 
 [env]
-_.python.venv = { path = ".venv", create = true }
+_.python.venv = { path = ".venv" }


### PR DESCRIPTION
### Summary 💡

This PR updates tempo to v2.8.2. It also updates drone CI to use mise images + a new test for kubernetes 1.33


Relates: https://github.com/sighupio/product-management/issues/663


### Description 📝

- update tempo-distributed's `deploy.yaml`
- added `mise.toml`
- updated `.drone.yml` to use mise images in the tests
- added kubernetes 1.33 test to drone pipeline
- updated docs

### Breaking Changes 💔

None

### Tests performed 🧪

```
kind create cluster --name test-e2e-kfd --image registry.sighup.io/fury/kindest/node:v1.33.2 && kind get kubeconfig --name test-e2e-kfd > ./kubeconfig
export KUBECONFIG=./kubeconfig
mise test
```
and [CI #262](https://ci.sighup.io/sighupio/module-tracing/262)

### Future work 🔧

None
