### PR TITLE
feat: upgrade Tempo to 2.10.5

### DIFF
--- a/katalog/tempo-distributed/MAINTENANCE.md
+++ b/katalog/tempo-distributed/MAINTENANCE.md
@@ -1,26 +1,26 @@
 # Tempo - maintenance
 
-To maintain the Tempo package, you should follow these steps.
+To update the Tempo package to the latest chart version, run:
 
 ```bash
-helm repo add grafana https://grafana.github.io/helm-charts
-helm repo update
-helm search repo grafana/tempo-distributed # get the latest chart version
-helm pull grafana/tempo-distributed --version 1.19.0 --untar --untardir /tmp # this command will download the chart in /tmp/tempo-distributed
+bash upgrade.sh
 ```
 
-Run the following command:
+The script will:
 
-```bash
-helm template tempo-distributed /tmp/tempo-distributed -n tracing --values MAINTENANCE.values.yaml > tempo-distributed-built.yaml
-```
+1. Pull the latest `grafana-community/tempo-distributed` Helm chart
+2. Update image tags in `MAINTENANCE.values.yaml` and `kustomization.yaml`
+3. Re-render `deploy.yaml` from the chart using `MAINTENANCE.values.yaml`
 
-With the `tempo-distributed-built.yaml` file, check differences with the current `deploy.yml` file and change accordingly.
+After running the script, review the changes in `deploy.yaml` and adjust if needed.
 
 What was customized:
 
-- nginx-unprivileged image was bumped to the latest available version
-- PodDisruptionBudget apiVersion bumped to policy/v1
+- `useExternalConfig: true` — ConfigMaps are managed via Kustomize (`configMapGenerator` in `kustomization.yaml` using `configs/tempo.yaml` and `configs/overrides.yaml`)
+- `metricsGenerator.enabled: false`
+- `memcachedExporter.enabled: false`
+- `queryFrontend.query.enabled: false`
+- Storage backend set to S3 (MinIO)
 
 
 ## Testing the tracing stack

--- a/katalog/tempo-distributed/MAINTENANCE.values.yaml
+++ b/katalog/tempo-distributed/MAINTENANCE.values.yaml
@@ -22,11 +22,9 @@ global:
   dnsNamespace: 'kube-system'
 fullnameOverride: ''
 # fullnameOverride: tempo
-
-
+useExternalConfig: true
 # -- If true, Tempo will report anonymous usage data about the shape of a deployment to Grafana Labs
 reportingEnabled: true
-
 tempo:
   image:
     # -- The Docker registry
@@ -36,9 +34,8 @@ tempo:
     # -- Docker image repository
     repository: grafana/tempo
     # -- Overrides the image tag whose default is the chart's appVersion
-    tag: null
+    tag: 2.10.5
     pullPolicy: IfNotPresent
-  
 # Configuration for the ingester
 ingester:
   # -- Number of replicas for the ingester
@@ -66,19 +63,17 @@ ingester:
     repository: null
     # -- Docker image tag for the ingester image. Overrides `tempo.image.tag`
     tag: null
-  resources: 
+  resources:
     requests:
       cpu: 50m
       memory: 128Mi
     limits:
-      cpu: 512m 
+      cpu: 512m
       memory: 1024Mi
-
 # Configuration for the metrics-generator
 metricsGenerator:
   # -- Specifies whether a metrics-generator should be deployed
   enabled: false
-  
 # Configuration for the distributor
 distributor:
   # -- Number of replicas for the distributor
@@ -110,14 +105,13 @@ distributor:
     repository: null
     # -- Docker image tag for the ingester image. Overrides `tempo.image.tag`
     tag: null
-  resources: 
+  resources:
     requests:
       cpu: 50m
       memory: 128Mi
     limits:
-      cpu: 512m 
+      cpu: 512m
       memory: 1024Mi
-
 # Configuration for the compactor
 compactor:
   # -- Number of replicas for the compactor
@@ -137,14 +131,13 @@ compactor:
     # -- Docker image tag for the compactor image. Overrides `tempo.image.tag`
     tag: null
   # -- The name of the PriorityClass for compactor pods
-  resources: 
+  resources:
     requests:
       cpu: 50m
       memory: 128Mi
     limits:
-      cpu: 512m 
+      cpu: 512m
       memory: 1024Mi
-
 # Configuration for the querier
 querier:
   # -- Number of replicas for the querier
@@ -176,33 +169,30 @@ querier:
     repository: null
     # -- Docker image tag for the querier image. Overrides `tempo.image.tag`
     tag: null
-  resources: 
+  resources:
     requests:
       cpu: 50m
       memory: 128Mi
     limits:
-      cpu: 512m 
+      cpu: 512m
       memory: 1024Mi
-
 # Configuration for the query-frontend
 queryFrontend:
   query:
     # -- Required for grafana version <7.5 for compatibility with jaeger-ui. Doesn't work on ARM arch
     enabled: false
-  resources: 
+  resources:
     requests:
       cpu: 50m
       memory: 128Mi
     limits:
-      cpu: 512m 
+      cpu: 512m
       memory: 1024Mi
-  
 # Configuration for the federation-frontend
 # Can only be enabled if enterprise.enabled is true - requires license.
 enterpriseFederationFrontend:
   # -- Specifies whether a federation-frontend should be deployed
   enabled: false
-
 traces:
   jaeger:
     grpc:
@@ -248,7 +238,6 @@ traces:
     receiverConfig: {}
   # -- Enable Tempo to ingest traces from Kafka. Reference: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkareceiver
   kafka: {}
-
 # To configure a different storage backend instead of local storage:
 # storage:
 #   trace:
@@ -271,7 +260,6 @@ storage:
       bucket: 'tempo'
       endpoint: 'minio-tracing:9000'
       insecure: true
-
 # memcached is for all of the Tempo pieces to coordinate with each other.
 # you can use your self memcacherd by set enable: false and host + service
 memcached:
@@ -285,22 +273,20 @@ memcached:
     # -- Memcached Docker image repository
     repository: memcached
     # -- Memcached Docker image tag
-    tag: 1.5.17-alpine
+    tag: 1.6.42-alpine
     # -- Memcached Docker image pull policy
     pullPolicy: IfNotPresent
   host: memcached
   # Number of replicas for memchached
   replicas: 1
   # -- Additional CLI args for memcached
-  resources: 
+  resources:
     requests:
       cpu: 50m
       memory: 128Mi
     limits:
-      cpu: 512m 
+      cpu: 512m
       memory: 1024Mi
- 
-
 memcachedExporter:
   # -- Specifies whether the Memcached Exporter should be enabled
   enabled: false
@@ -322,30 +308,25 @@ memcachedExporter:
     pullPolicy: IfNotPresent
     # -- Memcached Exporter resource requests and limits
   resources: {}
-
 metaMonitoring:
   # ServiceMonitor configuration
   serviceMonitor:
     # -- If enabled, ServiceMonitor resources for Prometheus Operator are created
     enabled: true
     # -- Alternative namespace for ServiceMonitor resources
-
   # metaMonitoringAgent configures the built in Grafana Agent that can scrape metrics and logs and send them to a local or remote destination
   grafanaAgent:
     # -- Controls whether to create PodLogs, MetricsInstance, LogsInstance, and GrafanaAgent CRs to scrape the
     # ServiceMonitors of the chart and ship metrics and logs to the remote endpoints below.
     # Note that you need to configure serviceMonitor in order to have some metrics available.
     enabled: false
-
 # Rules for the Prometheus Operator
 prometheusRule:
   # -- If enabled, a PrometheusRule resource for Prometheus Operator is created
   enabled: true
   # -- Alternative namespace for the PrometheusRule resource
-
 minio:
   enabled: false
-
 # Configuration for the gateway
 gateway:
   # -- Specifies whether the gateway should be enabled
@@ -380,13 +361,13 @@ gateway:
     # -- The gateway image repository
     repository: nginxinc/nginx-unprivileged
     # -- The gateway image tag
-    tag: 1.25-alpine
+    tag: 1.31-alpine
     # -- The gateway image pull policy
     pullPolicy: IfNotPresent
-  resources: 
+  resources:
     requests:
       cpu: 50m
       memory: 128Mi
     limits:
-      cpu: 512m 
+      cpu: 512m
       memory: 1024Mi

--- a/katalog/tempo-distributed/README.md
+++ b/katalog/tempo-distributed/README.md
@@ -2,12 +2,12 @@
 
 <!-- <SD-DOCS> -->
 
-Grafana Tempo is an open source, easy-to-use, and high-scale distributed tracing backend. Tempo is cost-efficient, requiring only object storage to operate, and is deeply integrated with Grafana, Prometheus, and Loki. Tempo can ingest common open source tracing protocols, including Jaeger, Zipkin, and OpenTelemetry.
+Grafana Tempo is an open-source, easy-to-use, and high-scale distributed tracing backend. Tempo is cost-efficient, requiring only object storage to operate, and is deeply integrated with Grafana, Prometheus, and Loki. Tempo can ingest common open source tracing protocols, including Jaeger, Zipkin, and OpenTelemetry.
 
 ## Requirements
 
-- Kubernetes >= `1.24.0`
-- Kustomize >= `v3.5.3`
+- Kubernetes >= `1.25.0`
+- Kustomize >= `3.5.3`
 - [prometheus-operator from SD monitoring module][prometheus-operator]
 - [grafana from SD monitoring module][grafana]
 
@@ -19,17 +19,17 @@ Grafana Tempo is an open source, easy-to-use, and high-scale distributed tracing
 
 ## Configuration
 
-Tempo is configured with the distributed approach. By default we configure 3 fixed ingesters and the other components in autoscaling mode.
+Tempo is configured with the distributed approach. By default, we configure 3 fixed ingesters and the other components in autoscaling mode.
 
 Each component has a default limit and request:
 
 ```yaml
 requests:
-    cpu: 50m
-    memory: 128Mi
+  cpu: 50m
+  memory: 128Mi
 limits:
-    cpu: 512m 
-    memory: 1024Mi
+  cpu: 512m
+  memory: 1024Mi
 ```
 
 

--- a/katalog/tempo-distributed/configs/overrides.yaml
+++ b/katalog/tempo-distributed/configs/overrides.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+overrides:
+  null

--- a/katalog/tempo-distributed/configs/tempo.yaml
+++ b/katalog/tempo-distributed/configs/tempo.yaml
@@ -95,7 +95,7 @@ query_frontend:
 server:
   grpc_server_max_recv_msg_size: 4194304
   grpc_server_max_send_msg_size: 4194304
-  http_listen_port: 3100
+  http_listen_port: 3200
   http_server_read_timeout: 30s
   http_server_write_timeout: 30s
   log_format: logfmt

--- a/katalog/tempo-distributed/deploy.yaml
+++ b/katalog/tempo-distributed/deploy.yaml
@@ -8,13 +8,14 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: tempo-distributed-ingester
+  namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -31,30 +32,12 @@ metadata:
   name: tempo-distributed
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: false
----
-# Source: tempo-distributed/templates/configmap-runtime.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: tempo-distributed-runtime
-  labels:
-    helm.sh/chart: tempo-distributed-1.47.1
-    app.kubernetes.io/name: tempo
-    app.kubernetes.io/instance: tempo-distributed
-    app.kubernetes.io/version: "2.8.2"
-    app.kubernetes.io/managed-by: Helm
-  namespace: "tracing"
-data:
-  overrides.yaml: |
-    
-    overrides:
-      null
 ---
 # Source: tempo-distributed/templates/gateway/configmap-gateway.yaml
 apiVersion: v1
@@ -63,11 +46,11 @@ metadata:
   name: tempo-distributed-gateway
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: gateway
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 data:
   nginx.conf: |
@@ -75,89 +58,100 @@ data:
     error_log  /dev/stderr;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
-
+    
     events {
       worker_connections  4096;  ## Default: 1024
     }
-
+    
     http {
       client_body_temp_path /tmp/client_temp;
       proxy_temp_path       /tmp/proxy_temp_path;
       fastcgi_temp_path     /tmp/fastcgi_temp;
       uwsgi_temp_path       /tmp/uwsgi_temp;
       scgi_temp_path        /tmp/scgi_temp;
-
+    
       proxy_http_version    1.1;
-
+    
       default_type application/octet-stream;
       log_format   main '$remote_addr - $remote_user [$time_local]  $status '
             '"$request" $body_bytes_sent "$http_referer" '
             '"$http_user_agent" "$http_x_forwarded_for"';
       access_log   /dev/stderr  main;
-
+    
       sendfile     on;
       tcp_nopush   on;
       resolver kube-dns.kube-system.svc.cluster.local;
-
+    
       server {
         listen             8080;
-
+    
         location = / {
           return 200 'OK';
           auth_basic off;
         }
-
+    
         location = /jaeger/api/traces {
-          proxy_pass       http://tempo-distributed-distributor.tracing.svc.cluster.local:14268/api/traces;
+          set $distributor tempo-distributed-distributor.tracing.svc.cluster.local;
+          proxy_pass       http://$distributor:14268/api/traces;
         }
-
+    
         location = /zipkin/spans {
-          proxy_pass       http://tempo-distributed-distributor.tracing.svc.cluster.local:9411/spans;
+          set $distributor tempo-distributed-distributor.tracing.svc.cluster.local;
+          proxy_pass       http://$distributor:9411/spans;
         }
-
+    
         location = /v1/traces {
-          proxy_pass       http://tempo-distributed-distributor.tracing.svc.cluster.local:4318/v1/traces;
+          set $distributor tempo-distributed-distributor.tracing.svc.cluster.local;
+          proxy_pass       http://$distributor:4318/v1/traces;
         }
-
+    
         location = /otlp/v1/traces {
-          proxy_pass       http://tempo-distributed-distributor.tracing.svc.cluster.local:4318/v1/traces;
+          set $distributor tempo-distributed-distributor.tracing.svc.cluster.local;
+          proxy_pass       http://$distributor:4318/v1/traces;
         }
-
+    
         location ^~ /api {
-          proxy_pass       http://tempo-distributed-query-frontend.tracing.svc.cluster.local:3100$request_uri;
+          set $query_frontend tempo-distributed-query-frontend.tracing.svc.cluster.local;
+          proxy_pass       http://$query_frontend:3200$request_uri;
         }
-
+    
         location = /flush {
-          proxy_pass       http://tempo-distributed-ingester.tracing.svc.cluster.local:3100$request_uri;
+          set $ingester tempo-distributed-ingester.tracing.svc.cluster.local;
+          proxy_pass       http://$ingester:3200$request_uri;
         }
-
+    
         location = /shutdown {
-          proxy_pass       http://tempo-distributed-ingester.tracing.svc.cluster.local:3100$request_uri;
+          set $ingester tempo-distributed-ingester.tracing.svc.cluster.local;
+          proxy_pass       http://$ingester:3200$request_uri;
         }
-
+    
         location = /distributor/ring {
-          proxy_pass       http://tempo-distributed-distributor.tracing.svc.cluster.local:3100$request_uri;
+          set $distributor tempo-distributed-distributor.tracing.svc.cluster.local;
+          proxy_pass       http://$distributor:3200$request_uri;
         }
-
+    
         location = /ingester/ring {
-          proxy_pass       http://tempo-distributed-distributor.tracing.svc.cluster.local:3100$request_uri;
+          set $distributor tempo-distributed-distributor.tracing.svc.cluster.local;
+          proxy_pass       http://$distributor:3200$request_uri;
         }
-
+    
         location = /compactor/ring {
-          proxy_pass       http://tempo-distributed-compactor.tracing.svc.cluster.local:3100$request_uri;
+          set $compactor tempo-distributed-compactor.tracing.svc.cluster.local;
+          proxy_pass       http://$compactor:3200$request_uri;
         }
-     
       }
       # OTLP gRPC
       server {
         listen               4317 http2;
     
         location = /opentelemetry.proto.collector.trace.v1.TraceService/Export {
-          grpc_pass          grpc://tempo-distributed-distributor.tracing.svc.cluster.local:4317;
+          set $distributor  tempo-distributed-distributor.tracing.svc.cluster.local;
+          grpc_pass         grpc://$distributor:4317;
         }
     
         location ~ /opentelemetry {
-          grpc_pass          grpc://tempo-distributed-distributor.tracing.svc.cluster.local:4317;
+          set $distributor  tempo-distributed-distributor.tracing.svc.cluster.local;
+          grpc_pass         grpc://$distributor:4317;
         }
       }
     }
@@ -169,18 +163,18 @@ metadata:
   name: tempo-distributed-compactor
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: compactor
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
   ports:
     - name: http-metrics
-      port: 3100
-      targetPort: 3100
+      port: 3200
+      targetPort: http-metrics
       protocol: TCP
   selector:
     app.kubernetes.io/name: tempo
@@ -196,11 +190,11 @@ metadata:
   name: tempo-distributed-distributor-discovery
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: distributor
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
 spec:
@@ -208,7 +202,7 @@ spec:
   clusterIP: None
   ports:
     - name: http-metrics
-      port: 3100
+      port: 3200
       targetPort: http-metrics
     - name: distributor-jaeger-thrift-compact
       port: 6831
@@ -258,11 +252,11 @@ metadata:
   name: tempo-distributed-distributor
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: distributor
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   internalTrafficPolicy: Cluster
@@ -271,7 +265,7 @@ spec:
   ipFamilyPolicy: SingleStack
   ports:
     - name: http-metrics
-      port: 3100
+      port: 3200
       targetPort: http-metrics
     - name: grpc
       port: 9095
@@ -325,14 +319,16 @@ metadata:
   name: tempo-distributed-gateway
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: gateway
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
+  ipFamilies: [IPv4]
+  ipFamilyPolicy: SingleStack
   ports:
     - name: http-metrics
       port: 80
@@ -355,11 +351,11 @@ metadata:
   name: tempo-distributed-gossip-ring
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: gossip-ring
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -385,11 +381,11 @@ metadata:
   name: tempo-distributed-ingester-discovery
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: ingester
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
     prometheus.io/service-monitor: "false"
 spec:
@@ -397,13 +393,13 @@ spec:
   clusterIP: None
   ports:
     - name: http-metrics
-      port: 3100
+      port: 3200
       protocol: TCP
-      targetPort: 3100
+      targetPort: http-metrics
     - name: grpc
       port: 9095
       protocol: TCP
-      targetPort: 9095
+      targetPort: grpc
   selector:
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
@@ -416,11 +412,11 @@ metadata:
   name: tempo-distributed-ingester
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: ingester
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -429,13 +425,13 @@ spec:
   ipFamilyPolicy: SingleStack
   ports:
     - name: http-metrics
-      port: 3100
+      port: 3200
       protocol: TCP
-      targetPort: 3100
+      targetPort: http-metrics
     - name: grpc
       port: 9095
       protocol: TCP
-      targetPort: 9095
+      targetPort: grpc
   selector:
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
@@ -448,19 +444,21 @@ metadata:
   name: tempo-distributed-memcached
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: memcached
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
+  type: ClusterIP
+  clusterIP: None
   ipFamilies: [IPv4]
   ipFamilyPolicy: SingleStack
   ports:
   - name: memcached-client
     port: 11211
-    targetPort: 11211
+    targetPort: client
   - name: http-metrics
     port: 9150
     targetPort: http-metrics
@@ -476,20 +474,20 @@ metadata:
   name: tempo-distributed-querier
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: querier
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   ipFamilies: [IPv4]
   ipFamilyPolicy: SingleStack
   ports:
     - name: http-metrics
-      port: 3100
+      port: 3200
       protocol: TCP
-      targetPort: 3100
+      targetPort: http-metrics
     - name: grpc
       port: 9095
       protocol: TCP
@@ -506,23 +504,23 @@ metadata:
   name: tempo-distributed-query-frontend-discovery
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
   clusterIP: None
   ports:
     - name: http
-      port: 3100
-      targetPort: 3100
+      port: 3200
+      targetPort: http-metrics
     - name: grpc
       port: 9095
       protocol: TCP
-      targetPort: 9095
+      targetPort: grpc
     - name: grpclb
       port: 9096
       protocol: TCP
@@ -540,11 +538,11 @@ metadata:
   name: tempo-distributed-query-frontend
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -552,12 +550,12 @@ spec:
   ipFamilyPolicy: SingleStack
   ports:
     - name: http-metrics
-      port: 3100
-      targetPort: 3100
+      port: 3200
+      targetPort: http-metrics
     - name: grpc
       port: 9095
       protocol: TCP
-      targetPort: 9095
+      targetPort: grpc
   selector:
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
@@ -570,12 +568,12 @@ metadata:
   name: tempo-distributed-compactor
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: compactor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -591,38 +589,55 @@ spec:
       maxSurge: 0
       maxUnavailable: 1
   template:
+    
     metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
       labels:
-        helm.sh/chart: tempo-distributed-1.47.1
+        helm.sh/chart: tempo-distributed-2.23.0
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo-distributed
-        app.kubernetes.io/version: "2.8.2"
+        app.kubernetes.io/version: "2.10.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: compactor
         app.kubernetes.io/part-of: memberlist
-      annotations:
-        checksum/config: 5a9a3b0ae5295b18bb327968ef57e62fc9a749a811277528321947603b3f0586
     spec:
       serviceAccountName: tempo-distributed
+      enableServiceLinks: false
       securityContext:
         fsGroup: 1000
-      enableServiceLinks: false
       
-      initContainers:
-        []
       containers:
-        - args:
+        - name: compactor
+          image: docker.io/grafana/tempo:2.10.5
+          imagePullPolicy: IfNotPresent
+          args:
             - -target=compactor
             - -config.file=/conf/tempo.yaml
-            - -mem-ballast-size-mbs=1024
-          image: docker.io/grafana/tempo:2.8.2
-          imagePullPolicy: IfNotPresent
-          name: compactor
           ports:
-            - containerPort: 3100
-              name: http-metrics
             - containerPort: 7946
               name: http-memberlist
+              protocol: TCP
+            - containerPort: 3200
+              name: http-metrics
+              protocol: TCP
+          env:
+            - name: GOMEMLIMIT
+              value: 870MiB
+            - name: GOGC
+              value: "80"
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
           resources:
             limits:
               cpu: 512m
@@ -689,12 +704,12 @@ metadata:
   name: tempo-distributed-distributor
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -709,37 +724,38 @@ spec:
       maxSurge: 0
       maxUnavailable: 1
   template:
+    
     metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
       labels:
-        helm.sh/chart: tempo-distributed-1.47.1
+        helm.sh/chart: tempo-distributed-2.23.0
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo-distributed
-        app.kubernetes.io/version: "2.8.2"
+        app.kubernetes.io/version: "2.10.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: distributor
         app.kubernetes.io/part-of: memberlist
-      annotations:
-        checksum/config: 5a9a3b0ae5295b18bb327968ef57e62fc9a749a811277528321947603b3f0586
     spec:
       serviceAccountName: tempo-distributed
+      enableServiceLinks: false
       securityContext:
         fsGroup: 1000
-      enableServiceLinks: false
       
       containers:
-        - args:
+        - name: distributor
+          image: docker.io/grafana/tempo:2.10.5
+          imagePullPolicy: IfNotPresent
+          args:
             - -target=distributor
             - -config.file=/conf/tempo.yaml
-            - -mem-ballast-size-mbs=1024
-          image: docker.io/grafana/tempo:2.8.2
-          imagePullPolicy: IfNotPresent
-          name: distributor
           ports:
             - containerPort: 7946
               name: http-memberlist
               protocol: TCP
-            - containerPort: 3100
+            - containerPort: 3200
               name: http-metrics
+              protocol: TCP
             - containerPort: 6831
               name: jaeger-compact
               protocol: UDP
@@ -764,6 +780,17 @@ spec:
             - containerPort: 55678
               name: opencensus
               protocol: TCP
+          env:
+            - name: GOMEMLIMIT
+              value: 870MiB
+            - name: GOGC
+              value: "80"
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /ready
@@ -846,11 +873,11 @@ metadata:
   name: tempo-distributed-gateway
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: gateway
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -863,7 +890,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e3f321142cca3f2ec8d8f2aca9b34bc1ee45830d9a6ff0ff3e59b515564f70a3
+        checksum/config: 575132d4cd301badda4065053bbd59f52694a9dd488e9d945b26dd09530bfa2d
       labels:
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo-distributed
@@ -877,7 +904,7 @@ spec:
       
       containers:
         - name: nginx
-          image: "docker.io/nginxinc/nginx-unprivileged:1.25-alpine"
+          image: "docker.io/nginxinc/nginx-unprivileged:1.31-alpine"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http-metrics
@@ -886,6 +913,12 @@ spec:
             - name: grpc-otlp
               containerPort: 4317
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http-metrics
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /
@@ -960,12 +993,12 @@ metadata:
   name: tempo-distributed-querier
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: querier
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -980,39 +1013,55 @@ spec:
       maxSurge: 0
       maxUnavailable: 1
   template:
+    
     metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
       labels:
-        helm.sh/chart: tempo-distributed-1.47.1
+        helm.sh/chart: tempo-distributed-2.23.0
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo-distributed
-        app.kubernetes.io/version: "2.8.2"
+        app.kubernetes.io/version: "2.10.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: querier
         app.kubernetes.io/part-of: memberlist
-      annotations:
-        checksum/config: 5a9a3b0ae5295b18bb327968ef57e62fc9a749a811277528321947603b3f0586
     spec:
       serviceAccountName: tempo-distributed
+      enableServiceLinks: false
       securityContext:
         fsGroup: 1000
-      enableServiceLinks: false
       
-      initContainers:
-        []
       containers:
-        - args:
+        - name: querier
+          image: docker.io/grafana/tempo:2.10.5
+          imagePullPolicy: IfNotPresent
+          args:
             - -target=querier
             - -config.file=/conf/tempo.yaml
-            - -mem-ballast-size-mbs=1024
-          image: docker.io/grafana/tempo:2.8.2
-          imagePullPolicy: IfNotPresent
-          name: querier
           ports:
             - containerPort: 7946
               name: http-memberlist
               protocol: TCP
-            - containerPort: 3100
+            - containerPort: 3200
               name: http-metrics
+              protocol: TCP
+          env:
+            - name: GOMEMLIMIT
+              value: 870MiB
+            - name: GOGC
+              value: "80"
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
           resources:
             limits:
               cpu: 512m
@@ -1029,12 +1078,6 @@ spec:
             runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: http-metrics
-            initialDelaySeconds: 30
-            timeoutSeconds: 1
           volumeMounts:
             - mountPath: /conf
               name: config
@@ -1095,11 +1138,11 @@ metadata:
   name: tempo-distributed-query-frontend
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 10
@@ -1115,37 +1158,58 @@ spec:
       maxSurge: 0
       maxUnavailable: 1
   template:
+    
     metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
       labels:
-        helm.sh/chart: tempo-distributed-1.47.1
+        helm.sh/chart: tempo-distributed-2.23.0
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo-distributed
-        app.kubernetes.io/version: "2.8.2"
+        app.kubernetes.io/version: "2.10.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
-      annotations:
-        checksum/config: 5a9a3b0ae5295b18bb327968ef57e62fc9a749a811277528321947603b3f0586
+        app.kubernetes.io/part-of: memberlist
     spec:
       serviceAccountName: tempo-distributed
+      enableServiceLinks: false
       securityContext:
         fsGroup: 1000
-      enableServiceLinks: false
       
-      initContainers:
-        []
       containers:
-        - args:
+        - name: query-frontend
+          image: docker.io/grafana/tempo:2.10.5
+          imagePullPolicy: IfNotPresent
+          args:
             - -target=query-frontend
             - -config.file=/conf/tempo.yaml
-            - -mem-ballast-size-mbs=1024
-          image: docker.io/grafana/tempo:2.8.2
-          imagePullPolicy: IfNotPresent
-          name: query-frontend
           ports:
-            - containerPort: 3100
+            - containerPort: 7946
+              name: http-memberlist
+              protocol: TCP
+            - containerPort: 3200
               name: http-metrics
+              protocol: TCP
             - containerPort: 9095
               name: grpc
+              protocol: TCP
+          env:
+            - name: GOMEMLIMIT
+              value: 870MiB
+            - name: GOGC
+              value: "80"
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
           resources:
             limits:
               cpu: 512m
@@ -1168,7 +1232,7 @@ spec:
             - mountPath: /runtime-config
               name: runtime-config
             - mountPath: /var/tempo
-              name: tempo-queryfrontend-store
+              name: tempo-query-frontend-store
       terminationGracePeriodSeconds: 30
       topologySpreadConstraints:
         - maxSkew: 1
@@ -1212,7 +1276,7 @@ spec:
             items:
               - key: "overrides.yaml"
                 path: "overrides.yaml"
-        - name: tempo-queryfrontend-store
+        - name: tempo-query-frontend-store
           emptyDir: {}
 ---
 # Source: tempo-distributed/templates/distributor/hpa.yaml
@@ -1222,11 +1286,11 @@ metadata:
   name: tempo-distributed-distributor
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: distributor
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -1250,11 +1314,11 @@ metadata:
   name: tempo-distributed-gateway
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: gateway
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -1278,11 +1342,11 @@ metadata:
   name: tempo-distributed-querier
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: querier
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -1305,16 +1369,17 @@ kind: StatefulSet
 metadata:
   name: tempo-distributed-ingester
   namespace: tracing
-  labels:    
-    helm.sh/chart: tempo-distributed-1.47.1
+  labels:
+    
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: ingester
-    app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 3
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/name: tempo
@@ -1328,15 +1393,15 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: tempo-distributed-1.47.1
+        helm.sh/chart: tempo-distributed-2.23.0
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo-distributed
-        app.kubernetes.io/version: "2.8.2"
+        app.kubernetes.io/version: "2.10.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: 5a9a3b0ae5295b18bb327968ef57e62fc9a749a811277528321947603b3f0586
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
     spec:
       serviceAccountName: tempo-distributed
       securityContext:
@@ -1349,8 +1414,7 @@ spec:
         - args:
             - -target=ingester
             - -config.file=/conf/tempo.yaml
-            - -mem-ballast-size-mbs=1024
-          image: docker.io/grafana/tempo:2.8.2
+          image: docker.io/grafana/tempo:2.10.5
           imagePullPolicy: IfNotPresent
           name: ingester
           ports:
@@ -1359,7 +1423,18 @@ spec:
             - name: http-memberlist
               containerPort: 7946
             - name: http-metrics
-              containerPort: 3100
+              containerPort: 3200
+          env:
+            - name: GOMEMLIMIT
+              value: 870MiB
+            - name: GOGC
+              value: "80"
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /ready
@@ -1443,28 +1518,29 @@ metadata:
   name: tempo-distributed-memcached
   namespace: tracing
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: memcached
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/name: tempo
       app.kubernetes.io/instance: tempo-distributed
       app.kubernetes.io/component: memcached
-  serviceName: memcached
+  serviceName: tempo-distributed-memcached
   template:
     metadata:
       labels:
-        helm.sh/chart: tempo-distributed-1.47.1
+        helm.sh/chart: tempo-distributed-2.23.0
         app.kubernetes.io/name: tempo
         app.kubernetes.io/instance: tempo-distributed
         app.kubernetes.io/component: memcached
-        app.kubernetes.io/version: "2.8.2"
+        app.kubernetes.io/version: "2.10.5"
         app.kubernetes.io/managed-by: Helm
     spec:
       serviceAccountName: tempo-distributed
@@ -1475,7 +1551,7 @@ spec:
       initContainers:
         []
       containers:
-        - image: docker.io/memcached:1.5.17-alpine
+        - image: docker.io/memcached:1.6.42-alpine
           imagePullPolicy: IfNotPresent
           name: memcached
           ports:
@@ -1553,10 +1629,10 @@ kind: PrometheusRule
 metadata:
   name: tempo-distributed
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   groups:
@@ -1569,12 +1645,12 @@ metadata:
   name: tempo-distributed-compactor
   namespace: "tracing"
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: compactor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   namespaceSelector:
@@ -1606,12 +1682,12 @@ metadata:
   name: tempo-distributed-distributor
   namespace: "tracing"
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   namespaceSelector:
@@ -1643,12 +1719,12 @@ metadata:
   name: tempo-distributed-ingester
   namespace: "tracing"
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   namespaceSelector:
@@ -1673,79 +1749,6 @@ spec:
           targetLabel: job
       scheme: http
 ---
-# Source: tempo-distributed/templates/memcached/servicemonitor-memcached.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: tempo-distributed-memcached
-  namespace: "tracing"
-  labels:
-    helm.sh/chart: tempo-distributed-1.47.1
-    app.kubernetes.io/name: tempo
-    app.kubernetes.io/instance: tempo-distributed
-    app.kubernetes.io/component: memcached
-    app.kubernetes.io/version: "2.8.2"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  namespaceSelector:
-    matchNames:
-    - tracing
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: tempo
-      app.kubernetes.io/instance: tempo-distributed
-      app.kubernetes.io/component: memcached
-    matchExpressions:
-      - key: prometheus.io/service-monitor
-        operator: NotIn
-        values:
-          - "false"
-  endpoints:
-    - port: http-metrics
-      relabelings:
-        - action: replace
-          sourceLabels: [job]
-          replacement: "tracing/memcached"
-          targetLabel: job
-      scheme: http
----
-# Source: tempo-distributed/templates/metrics-generator/servicemonitor-metrics-generator.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: tempo-distributed-metrics-generator
-  namespace: "tracing"
-  labels:
-    helm.sh/chart: tempo-distributed-1.47.1
-    app.kubernetes.io/name: tempo
-    app.kubernetes.io/instance: tempo-distributed
-    app.kubernetes.io/component: metrics-generator
-    app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.8.2"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  namespaceSelector:
-    matchNames:
-    - tracing
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: tempo
-      app.kubernetes.io/instance: tempo-distributed
-      app.kubernetes.io/component: metrics-generator
-    matchExpressions:
-      - key: prometheus.io/service-monitor
-        operator: NotIn
-        values:
-          - "false"
-  endpoints:
-    - port: http-metrics
-      relabelings:
-        - action: replace
-          sourceLabels: [job]
-          replacement: "tracing/metrics-generator"
-          targetLabel: job
-      scheme: http
----
 # Source: tempo-distributed/templates/querier/servicemonitor-querier.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -1753,12 +1756,12 @@ metadata:
   name: tempo-distributed-querier
   namespace: "tracing"
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: querier
     app.kubernetes.io/part-of: memberlist
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   namespaceSelector:
@@ -1783,42 +1786,6 @@ spec:
           targetLabel: job
       scheme: http
 ---
-# Source: tempo-distributed/templates/query-frontend/servicemonitor-jaeger-query.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: tempo-distributed-tempo-query
-  namespace: "tracing"
-  labels:
-    helm.sh/chart: tempo-distributed-1.47.1
-    app.kubernetes.io/name: tempo
-    app.kubernetes.io/instance: tempo-distributed
-    app.kubernetes.io/component: tempo-query
-    app.kubernetes.io/version: "2.8.2"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  namespaceSelector:
-    matchNames:
-    - tracing
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: tempo
-      app.kubernetes.io/instance: tempo-distributed
-      app.kubernetes.io/component: tempo-query
-    matchExpressions:
-      - key: prometheus.io/service-monitor
-        operator: NotIn
-        values:
-          - "false"
-  endpoints:
-    - port: http-metrics
-      relabelings:
-        - action: replace
-          sourceLabels: [job]
-          replacement: "tracing/tempo-query"
-          targetLabel: job
-      scheme: http
----
 # Source: tempo-distributed/templates/query-frontend/servicemonitor-query-frontend.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -1826,11 +1793,11 @@ metadata:
   name: tempo-distributed-query-frontend
   namespace: "tracing"
   labels:
-    helm.sh/chart: tempo-distributed-1.47.1
+    helm.sh/chart: tempo-distributed-2.23.0
     app.kubernetes.io/name: tempo
     app.kubernetes.io/instance: tempo-distributed
     app.kubernetes.io/component: query-frontend
-    app.kubernetes.io/version: "2.8.2"
+    app.kubernetes.io/version: "2.10.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   namespaceSelector:

--- a/katalog/tempo-distributed/kustomization.yaml
+++ b/katalog/tempo-distributed/kustomization.yaml
@@ -5,28 +5,27 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: tracing
-
 resources:
   - ns.yaml
   - datasource
   - deploy.yaml
-
-
 images:
   - name: docker.io/memcached
     newName: registry.sighup.io/fury/memcached
-    newTag: "1.6.37-alpine"
+    newTag: "1.6.42-alpine"
   - name: docker.io/grafana/tempo
     newName: registry.sighup.io/fury/grafana/tempo
-    newTag: "2.8.2"
+    newTag: "2.10.5"
   - name: docker.io/nginxinc/nginx-unprivileged
     newName: registry.sighup.io/fury/nginxinc/nginx-unprivileged
-    newTag: "1.27-alpine"
-
+    newTag: "1.31-alpine"
 configMapGenerator:
   - name: tempo-distributed-config
     namespace: tracing
     files:
       - configs/tempo.yaml
+  - name: tempo-distributed-runtime
+    namespace: tracing
+    files:
+      - configs/overrides.yaml

--- a/katalog/tempo-distributed/upgrade.sh
+++ b/katalog/tempo-distributed/upgrade.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+set -euo pipefail
+
+helm repo add grafana-community https://grafana-community.github.io/helm-charts
+helm repo update
+
+CHART_VERSION=$(helm search repo grafana-community/tempo-distributed -o json | yq '.[0].version')
+echo "Found chart version $CHART_VERSION"
+
+rm -rf /tmp/tempo-distributed
+helm pull grafana-community/tempo-distributed --version "$CHART_VERSION" --untar --untardir /tmp
+echo "Downloaded chart with version $CHART_VERSION in /tmp/tempo-distributed"
+
+TEMPO_TAG=$(yq '.appVersion' /tmp/tempo-distributed/Chart.yaml)
+MEMCACHED_TAG=$(yq '.memcached.image.tag' /tmp/tempo-distributed/values.yaml)
+NGINX_TAG=$(yq '.gateway.image.tag' /tmp/tempo-distributed/values.yaml)
+echo "Found latest image tags: tempo=$TEMPO_TAG memcached=$MEMCACHED_TAG nginx=$NGINX_TAG"
+
+yq -i ".tempo.image.tag = \"$TEMPO_TAG\"" MAINTENANCE.values.yaml
+yq -i ".memcached.image.tag = \"$MEMCACHED_TAG\"" MAINTENANCE.values.yaml
+yq -i ".gateway.image.tag = \"$NGINX_TAG\"" MAINTENANCE.values.yaml
+echo "Updated image tags in MAINTENANCE.values.yaml"
+
+yq -i "(.images[] | select(.name == \"docker.io/grafana/tempo\")).newTag = \"$TEMPO_TAG\"" kustomization.yaml
+yq -i "(.images[] | select(.name == \"docker.io/memcached\")).newTag = \"$MEMCACHED_TAG\"" kustomization.yaml
+yq -i "(.images[] | select(.name == \"docker.io/nginxinc/nginx-unprivileged\")).newTag = \"$NGINX_TAG\"" kustomization.yaml
+echo "Updated image tags in kustomization.yaml"
+
+helm template tempo-distributed /tmp/tempo-distributed -n tracing --values MAINTENANCE.values.yaml > deploy.yaml
+echo "Built chart template in deploy.yaml file"
+
+mise run add-license


### PR DESCRIPTION
### Summary 💡

Update Grafana Tempo images and chart.
Official chart is [deprecated](https://github.com/grafana/helm-charts/blob/main/charts/tempo-distributed/Chart.yaml#L7) so I changed it to the [community version](https://github.com/grafana-community/helm-charts/tree/main/charts/tempo-distributed).
Depends on #19 .

### Description 📝

#### Manual edits
- Created an utility script to do the upgrade: `upgrade.sh.`
- We create a custom ConfigMap for the `tempo-distributed-config` from the file [tempo.yaml](katalog/tempo-distributed/configs/tempo.yaml) so I added `useExternalConfig: true` to the helm values([MAINTENANCE.values.yaml](katalog/tempo-distributed/MAINTENANCE.values.yaml)). Due to that, the upstream chart does not generate the `tempo-distributed-runtime` ConfigMap so I added it in [overrides.yaml](katalog/tempo-distributed/configs/overrides.yaml).
- Upgraded min K8S version: https://github.com/grafana-community/helm-charts/tree/tempo-distributed-2.23.0/charts/tempo-distributed#requirements

#### Changes from upstream chart

The upstream chart now wraps several templates with conditional guards (`{{- if ... }}`), so resources like the configmap-runtime and some ServiceMonitors are no longer rendered when the corresponding values are disabled:
- `servicemonitor-metrics-generator.yaml` → `{{- if .Values.metricsGenerator.enabled }}`
- `servicemonitor-memcached.yaml` → `{{- if and .Values.memcached.enabled .Values.memcachedExporter.enabled }}`
- `servicemonitor-jaeger-query.yaml` → `{{- if .Values.queryFrontend.query.enabled }}`
Since our `MAINTENANCE.values.yaml` has these features disabled, the new `deploy.yaml` correctly no longer includes those resources.

### Breaking Changes 💔

There are breaking changes but we shouldn't be affected by them.
Upgrade guide will be included to the release PR (#22)

### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-tracing/376

### Future work 🔧

Update the MinIO image and chart.