### PR TITLE
feat: upgrade minio to use chainguard image

### DIFF
--- a/katalog/minio-ha/MAINTENANCE.md
+++ b/katalog/minio-ha/MAINTENANCE.md
@@ -1,22 +1,16 @@
 # MinIO HA - maintenance
 
-To maintain the MinIO package, you should follow these steps.
-
-Download the latest tgz from [Main Minio repository releases](https://github.com/minio/minio/releases).
-
-Extract to a folder of your choice, for example: `/tmp/minio`.
-
-Run the following command:
+To upgrade the MinIO package, run:
 
 ```bash
-helm template minio-tracing /tmp/minio/helm/minio --values MAINTENANCE.values.yaml -n tracing > minio-built.yaml
+./upgrade.sh
 ```
 
-Minio's helm comes packaged with a specific mc (its client) version, to find out
-which version comes with it you can inspect `/tmp/minio/helm/minio/values.yaml`.
+The script automatically:
 
-What was customized (what differs from the helm template command):
-
-- Config has been moved from the template output and generated via kustomize
-- Added `preferredDuringSchedulingIgnoredDuringExecution` on minio pods
-
+1. Fetches the latest release from [chainguard-forks/minio](https://github.com/chainguard-forks/minio/releases)
+2. Fetches the latest mc release from [minio/mc](https://github.com/minio/mc/releases)
+3. Downloads and extracts the Helm chart
+4. Updates image tags in `MAINTENANCE.values.yaml` and `kustomization.yaml`
+5. Re-renders `deploy.yaml` (excluding the ConfigMap, which is managed via kustomize)
+6. Runs `mise run add-license`

--- a/katalog/minio-ha/MAINTENANCE.values.yaml
+++ b/katalog/minio-ha/MAINTENANCE.values.yaml
@@ -4,43 +4,45 @@
 
 image:
   repository: registry.sighup.io/fury/minio
-  tag: RELEASE.2024-10-13T13-34-11Z
+  tag: RELEASE.2026-05-20T23-44-52Z-chainguard
   pullPolicy: IfNotPresent
-
 mcImage:
   repository: registry.sighup.io/fury/minio/mc
-  tag: RELEASE.2024-10-08T09-37-26Z
+  tag: "RELEASE.2025-08-13T08-35-41Z"
   pullPolicy: IfNotPresent
-
 mode: distributed
-
 rootUser: "minio"
 rootPassword: "minio123"
-
+existingSecret: "minio-tracing"
 # Number of drives attached to a node
 drivesPerNode: 2
 # Number of MinIO containers running
 replicas: 3
 # Number of expanded MinIO clusters
 pools: 1
-
 ## TLS Settings for MinIO
 tls:
   enabled: false
-
 persistence:
   enabled: true
   size: 10Gi
-
 ingress:
   enabled: false
-
 consoleIngress:
   enabled: false
-
-affinity: {}
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: "release"
+                operator: In
+                values:
+                  - minio-tracing
+          topologyKey: "kubernetes.io/hostname"
 topologySpreadConstraints: []
-
 ## Add stateful containers to have security context, if enabled MinIO will run as this
 ## user and group NOTE: securityContext is only enabled if persistence.enabled=true
 securityContext:
@@ -49,42 +51,36 @@ securityContext:
   runAsGroup: 1000
   fsGroup: 1000
   fsGroupChangePolicy: "OnRootMismatch"
-
 # Additational pod annotations
 podAnnotations: {}
-
 # Additional pod labels
 podLabels: {}
-
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
 resources:
   requests:
     memory: 512Mi
-
 ## List of users to be created after minio install
 ##
 users: []
-  ## Username, password and policy to be assigned to the user
-  ## Default policies are [readonly|readwrite|writeonly|consoleAdmin|diagnostics]
-  ## Add new policies as explained here https://min.io/docs/minio/kubernetes/upstream/administration/identity-access-management.html#access-management
-  ## NOTE: this will fail if LDAP is enabled in your MinIO deployment
-  ## make sure to disable this if you are using LDAP.
-  #- accessKey: console
-  #  secretKey: console123
-  #  policy: consoleAdmin
-  # Or you can refer to specific secret
-  #- accessKey: externalSecret
-  #  existingSecret: my-secret
-  #  existingSecretKey: password
-  #  policy: readonly
+## Username, password and policy to be assigned to the user
+## Default policies are [readonly|readwrite|writeonly|consoleAdmin|diagnostics]
+## Add new policies as explained here https://min.io/docs/minio/kubernetes/upstream/administration/identity-access-management.html#access-management
+## NOTE: this will fail if LDAP is enabled in your MinIO deployment
+## make sure to disable this if you are using LDAP.
+#- accessKey: console
+#  secretKey: console123
+#  policy: consoleAdmin
+# Or you can refer to specific secret
+#- accessKey: externalSecret
+#  existingSecret: my-secret
+#  existingSecretKey: password
+#  policy: readonly
 
 ## List of buckets to be created after minio install
 ##
 buckets: []
-
-
 ## Specify the service account to use for the MinIO pods. If 'create' is set to 'false'
 ## and 'name' is left unspecified, the account 'default' will be used.
 serviceAccount:
@@ -92,7 +88,6 @@ serviceAccount:
   ## The name of the service account to use. If 'create' is 'true', a service account with that name
   ## will be created.
   name: "minio-sa"
-
 metrics:
   serviceMonitor:
     enabled: true
@@ -104,8 +99,8 @@ metrics:
     relabelConfigs: {}
     # for cluster metrics
     relabelConfigsCluster: {}
-      # metricRelabelings:
-      #   - regex: (server|pod)
+    # metricRelabelings:
+    #   - regex: (server|pod)
     #     action: labeldrop
     # namespace: monitoring
     # interval: 30s

--- a/katalog/minio-ha/README.md
+++ b/katalog/minio-ha/README.md
@@ -9,7 +9,7 @@ In order to achieve high availability (HA) for MinIO, a cluster of multiple MinI
 ## Requirements
 
 - Kubernetes >= `1.23.0`
-- Kustomize >= `v3.5.3`
+- Kustomize >= `3.5.3`
 - [prometheus-operator from SD monitoring module][prometheus-operator]
 
 > Prometheus Operator is necessary since we configure a `ServiceMonitor` to make

--- a/katalog/minio-ha/deploy.yaml
+++ b/katalog/minio-ha/deploy.yaml
@@ -100,19 +100,10 @@ spec:
       labels:
         app: minio
         release: minio-tracing
+      annotations:
+        checksum/secrets: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum/config: 8571d3b5b6f25d0d5d098e627beaf790c5150b4a64496fef8176fd0582079021
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: "release"
-                      operator: In
-                      values:
-                        - minio-tracing
-                topologyKey: "kubernetes.io/hostname"
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
@@ -121,13 +112,9 @@ spec:
       serviceAccountName: minio-sa
       containers:
         - name: minio
-          image: registry.sighup.io/fury/minio:RELEASE.2024-10-13T13-34-11Z
+          image: registry.sighup.io/fury/minio:RELEASE.2026-05-20T23-44-52Z-chainguard
           imagePullPolicy: IfNotPresent
-          command: [
-            "/bin/sh",
-            "-ce",
-            "/usr/bin/docker-entrypoint.sh minio server http://minio-tracing-{0...2}.minio-tracing-svc.tracing.svc/export-{0...1} -S /etc/minio/certs/ --address :9000 --console-address :9001"
-          ]
+          command: ["/bin/sh", "-ce", "/usr/bin/docker-entrypoint.sh minio server http://minio-tracing-{0...2}.minio-tracing-svc.tracing.svc/export-{0...1} -S /etc/minio/certs/ --address :9000 --console-address :9001"]
           volumeMounts:
             - name: export-0
               mountPath: /export-0
@@ -153,10 +140,21 @@ spec:
               value: "public"
           resources:
             requests:
-              cpu: 100m
               memory: 512Mi
           securityContext:
             readOnlyRootFilesystem: false
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: release
+                      operator: In
+                      values:
+                        - minio-tracing
+                topologyKey: kubernetes.io/hostname
+              weight: 100
       volumes:
         - name: minio-user
           secret:
@@ -167,7 +165,7 @@ spec:
       metadata:
         name: export-0
       spec:
-        accessModes: [ "ReadWriteOnce" ]
+        accessModes: ["ReadWriteOnce"]
         resources:
           requests:
             storage: 10Gi
@@ -176,7 +174,7 @@ spec:
       metadata:
         name: export-1
       spec:
-        accessModes: [ "ReadWriteOnce" ]
+        accessModes: ["ReadWriteOnce"]
         resources:
           requests:
             storage: 10Gi
@@ -200,7 +198,7 @@ spec:
   targets:
     staticConfig:
       static:
-      - minio-tracing.tracing
+        - minio-tracing.tracing
 ---
 # Source: minio/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1

--- a/katalog/minio-ha/initialize-minio-buckets.yaml
+++ b/katalog/minio-ha/initialize-minio-buckets.yaml
@@ -27,7 +27,7 @@ spec:
           args: ["pod", "-lapp=minio"]
       containers:
         - name: mc
-          image: registry.sighup.io/fury/minio/mc
+          image: quay.io/minio/mc
           imagePullPolicy: Always
           envFrom:
             - secretRef:

--- a/katalog/minio-ha/kustomization.yaml
+++ b/katalog/minio-ha/kustomization.yaml
@@ -5,24 +5,23 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: tracing
-
 resources:
   - deploy.yaml
   - initialize-minio-buckets.yaml
   - prometheusrules.yaml
-
 images:
   - name: registry.sighup.io/fury/groundnuty/k8s-wait-for
+    newName: registry.sighup.io/fury/groundnuty/k8s-wait-for
     newTag: v2.0
-  - name: registry.sighup.io/fury/minio/mc
+  - name: quay.io/minio/mc
+    newName: registry.sighup.io/fury/minio/mc
     newTag: RELEASE.2025-08-13T08-35-41Z
-  - name: registry.sighup.io/fury/minio
-    newTag: RELEASE.2025-09-07T16-13-09Z
-
+  - name: quay.io/minio/minio
+    newName: registry.sighup.io/fury/minio
+    newTag: RELEASE.2026-05-20T23-44-52Z-chainguard
 secretGenerator:
   - name: minio-tracing
     literals:
-    - rootPassword=minio123
-    - rootUser=minio
+      - rootPassword=minio123
+      - rootUser=minio

--- a/katalog/minio-ha/upgrade.sh
+++ b/katalog/minio-ha/upgrade.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+set -euo pipefail
+
+MINIO_RELEASE=$(curl -sL "https://api.github.com/repos/chainguard-forks/minio/releases/latest" | jq -r ".tag_name")
+MINIO_TAG="${MINIO_RELEASE}-chainguard"
+echo "Found latest MinIO release $MINIO_RELEASE. MinIO tag will be $MINIO_TAG"
+
+MC_RELEASE=$(curl -sL "https://api.github.com/repos/minio/mc/releases/latest" | jq -r ".tag_name")
+echo "Found latest MC release $MC_RELEASE"
+
+mkdir -p /tmp/minio-chainguard
+curl -sL "https://api.github.com/repos/chainguard-forks/minio/tarball/${MINIO_RELEASE}" -o /tmp/minio-chainguard/release.tar.gz
+echo "Downloaded archive"
+
+tar xf /tmp/minio-chainguard/release.tar.gz -C /tmp/minio-chainguard --strip-components=1
+echo "Extracted archive"
+
+yq -i ".image.tag = \"${MINIO_TAG}\"" MAINTENANCE.values.yaml
+yq -i ".mcImage.tag = \"${MC_RELEASE}\"" MAINTENANCE.values.yaml
+echo "Updated image tags in MAINTENANCE.values.yaml"
+
+yq -i "(.images[] | select(.name == \"quay.io/minio/minio\")).newTag = \"${MINIO_TAG}\"" kustomization.yaml
+yq -i "(.images[] | select(.name == \"quay.io/minio/mc\")).newTag = \"${MC_RELEASE}\"" kustomization.yaml
+echo "Updated image tags in kustomization.yaml"
+
+helm template minio-tracing /tmp/minio-chainguard/helm/minio --values MAINTENANCE.values.yaml -n tracing \
+  | yq 'select(.kind != "ConfigMap" or .metadata.name != "minio-tracing")' > deploy.yaml
+echo "Template generated in deploy.yaml"
+
+rm -r /tmp/minio-chainguard
+mise run add-license


### PR DESCRIPTION
### Summary 💡

Migrating to [Chainguard image](https://github.com/chainguard-forks/minio) for MinIO due to archiving of original project.
Depends on #20 .

### Description 📝

- Created an utility script to do the upgrade: upgrade.sh.
- Use an updated MinIO MC (CLI) image instead of the old one defined in the helm chart.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-tracing/382

### Future work 🔧

Prepare the release.