### PR TITLE
feat: prepare release for v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </h1>
 <!-- markdownlint-enable MD033 MD045 -->
 
-![Release](https://img.shields.io/badge/Latest%20Release-v1.4.0-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v1.5.0-blue)
 ![License](https://img.shields.io/github/license/sighupio/module-tracing?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -27,23 +27,24 @@ The module contains the [tempo][tempo-page] tool from grafana.
 
 All the components are deployed in the `tracing` namespace in the cluster.
 
-| Package                                        | Version                         | Description                     |
-| ---------------------------------------------- | ------------------------------- | ------------------------------- |
-| [tempo-distributed](katalog/tempo-distributed) | `2.8.2`                         | Distributed Tempo deployment    |
-| [minio-ha](katalog/minio-ha)                   | `RELEASE.2025-09-07T16-13-09Z`  | Three nodes HA MinIO deployment |
+| Package                                        | Version                        | Description                     |
+| ---------------------------------------------- |--------------------------------| ------------------------------- |
+| [tempo-distributed](katalog/tempo-distributed) | `2.10.5`                       | Distributed Tempo deployment    |
+| [minio-ha](katalog/minio-ha)                   | `RELEASE.2026-05-20T23-44-52Z` | Three nodes HA MinIO deployment |
 
 Click on each package to see its full documentation.
 
 ## Compatibility
 
 | Kubernetes Version |   Compatibility    | Notes           |
-| ------------------ | :----------------: | --------------- |
+|--------------------| :----------------: | --------------- |
 | `1.29.x`           | :white_check_mark: | No known issues |
 | `1.30.x`           | :white_check_mark: | No known issues |
 | `1.31.x`           | :white_check_mark: | No known issues |
 | `1.32.x`           | :white_check_mark: | No known issues |
 | `1.33.x`           | :white_check_mark: | No known issues |
 | `1.34.x`           | :white_check_mark: | No known issues |
+| `1.35.x`           | :white_check_mark: | No known issues |
 
 Check the [compatibility matrix][compatibility-matrix] for additional information about previous releases of the modules.
 
@@ -74,7 +75,7 @@ spec:
 
 #### Sending Traces to Tempo
 
-To send traces form an instrumented application to Tempo, point the application to the Distributor's service:
+To send traces from an instrumented application to Tempo, point the application to the Distributor's service:
 
 ```plaintext
 tempo-distributed-distributor.tracing.svc.cluster.local:4317/
@@ -92,7 +93,7 @@ tempo-distributed-distributor.tracing.svc.cluster.local:4317/
 ```yaml
 bases:
   - name: tracing
-    version: "v1.4.0"
+    version: "v1.5.0"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
@@ -142,6 +143,6 @@ In case you experience any problems with the module, please [open a new issue](h
 
 ## License
 
-This module is open-source and it's released under the following [LICENSE](LICENSE)
+This module is open-source, and it's released under the following [LICENSE](LICENSE)
 
 <!-- </FOOTER> -->

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,15 +1,16 @@
 # Compatibility Matrix
 
-| Module Version / Kubernetes Version | 1.26.X             | 1.27.X             | 1.28.X             | 1.29.X             | 1.30.X             | 1.31.X             | 1.32.X             | 1.33.X             | 1.34.X             |
-| ----------------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
-| v1.0.0                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                    |
-| v1.0.1                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                    |
-| v1.0.2                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                    |
-| v1.0.3                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |
-| v1.1.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.2.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
-| v1.3.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
-| v1.4.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Module Version / Kubernetes Version | 1.26.X             | 1.27.X             | 1.28.X             | 1.29.X             | 1.30.X             | 1.31.X             | 1.32.X             | 1.33.X             | 1.34.X             | 1.35.X             |
+|-------------------------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
+| v1.0.0                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                    |                    |
+| v1.0.1                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                    |                    |
+| v1.0.2                              | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                    |                    |
+| v1.0.3                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |
+| v1.1.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.2.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
+| v1.3.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
+| v1.4.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
+| v1.5.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v1.5.0.md
+++ b/docs/releases/v1.5.0.md
@@ -1,0 +1,42 @@
+# Tracing Core Module Release 1.5.0
+
+Welcome to the latest release of the `tracing` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution)
+maintained by team SIGHUP by ReeVo.
+
+This release adds the support to Kubernetes 1.35 and updates Grafana Tempo & MinIO.
+
+## Component Images 🚢
+
+| Component           | Supported Version                                                                                  | Previous Version                |
+| ------------------- |----------------------------------------------------------------------------------------------------|---------------------------------|
+| `tempo-distributed` | [`2.10.5`](https://github.com/grafana/tempo/releases/tag/v2.10.5)                                  | `2.8.2`                         |
+| `minio-ha`          | [`RELEASE.2026-05-20T23-44-52Z`](https://github.com/chainguard-forks/minio/releases/tag/RELEASE.2026-05-20T23-44-52Z) | `RELEASE.2025-09-07T16-13-09Z` |
+
+## Update Guide 🦮
+
+### Process
+
+> **Warning**: This release includes a breaking change in the Tempo Helm chart that makes the memcached
+> Services headless and changes the StatefulSet `serviceName`. A manual migration step is required
+> **before** applying the new manifests. See the steps below.
+
+#### Step 1 — Migrate memcached resources
+
+Before applying the new manifests, delete the existing memcached Services and StatefulSets.
+The `--cascade=orphan` flag keeps the pods running to minimize downtime:
+
+```bash
+kubectl -n tracing delete service --selector 'app.kubernetes.io/instance=tempo-distributed,app.kubernetes.io/component in (memcached,memcached-bloom,memcached-parquet-footer,memcached-frontend-search)'
+
+kubectl -n tracing delete statefulset --selector 'app.kubernetes.io/instance=tempo-distributed,app.kubernetes.io/component in (memcached,memcached-bloom,memcached-parquet-footer,memcached-frontend-search)' --cascade=orphan
+```
+
+#### Step 2 — Apply the new manifests
+
+To upgrade the module run:
+
+```bash
+kustomize build | kubectl apply -f -
+```
+
+The new StatefulSets will adopt the existing pods and perform a rolling upgrade.

--- a/docs/releases/v1.5.0.md
+++ b/docs/releases/v1.5.0.md
@@ -1,4 +1,4 @@
-# Tracing Core Module Release 1.5.0
+# Tracing Core Module Release v1.5.0
 
 Welcome to the latest release of the `tracing` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution)
 maintained by team SIGHUP by ReeVo.


### PR DESCRIPTION
### Summary 💡

Prepare for release 1.5.0 .
Depends on #21 .


### Description 📝

- Added migration guide to Grafana Tempo.
- Changed MinIO refs to the chainguard fork.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

I manually executed the test:
- Created a kind cluster with version 1.35
- Deployed MinIO and Tempo with original versions
- Checked all was fine: Tempo was populating the bucket
- Deployed new versions
- Checked all was fine: Tempo was populating the bucket

CI with E2E: https://ci.sighup.io/sighupio/module-tracing/387
CI with release: https://ci.sighup.io/sighupio/module-tracing/404

### Future work 🔧

Not planned.